### PR TITLE
Event samle klassifisering

### DIFF
--- a/domene/loslager/src/main/java/no/nav/foreldrepenger/loslager/oppgave/OppgaveEgenskap.java
+++ b/domene/loslager/src/main/java/no/nav/foreldrepenger/loslager/oppgave/OppgaveEgenskap.java
@@ -47,10 +47,14 @@ public class OppgaveEgenskap extends BaseEntitet{
         this.andreKriterierType = andreKriterierType;
     }
 
-    public OppgaveEgenskap(Oppgave oppgave, AndreKriterierType andreKriterierType, String sisteSaksbehandlerForTotrinn) {
+    public OppgaveEgenskap(Oppgave oppgave, AndreKriterierType type, String sisteSaksbehandlerForTotrinn) {
         this.oppgave = oppgave;
-        this.andreKriterierType = andreKriterierType;
+        this.andreKriterierType = type;
         this.sisteSaksbehandlerForTotrinn = sisteSaksbehandlerForTotrinn;
+    }
+
+    public OppgaveEgenskap beslutterEgenskapFra(Oppgave oppgave, String sisteSaksbehandlerForTotrinn) {
+        return new OppgaveEgenskap(oppgave, AndreKriterierType.TIL_BESLUTTER, sisteSaksbehandlerForTotrinn);
     }
 
     public Oppgave getOppgave() {
@@ -75,5 +79,9 @@ public class OppgaveEgenskap extends BaseEntitet{
 
     public void aktiverOppgaveEgenskap() {
         aktiv = true;
+    }
+
+    public void setSisteSaksbehandlerForTotrinn(String sisteSaksbehandlerForTotrinn) {
+        this.sisteSaksbehandlerForTotrinn = sisteSaksbehandlerForTotrinn;
     }
 }

--- a/kafkatjenester/src/main/java/no/nav/fplos/kafkatjenester/FpsakAksjonspunkt.java
+++ b/kafkatjenester/src/main/java/no/nav/fplos/kafkatjenester/FpsakAksjonspunkt.java
@@ -1,0 +1,55 @@
+package no.nav.fplos.kafkatjenester;
+
+import no.nav.foreldrepenger.loslager.oppgave.AndreKriterierType;
+import no.nav.fplos.foreldrepengerbehandling.Aksjonspunkt;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static no.nav.fplos.kafkatjenester.util.StreamUtil.safeStream;
+
+public class FpsakAksjonspunkt {
+
+    private final List<Aksjonspunkt> aksjonspunkt;
+    private final List<AndreKriterierType> kriterier;
+
+    public FpsakAksjonspunkt(List<Aksjonspunkt> aksjonspunkt) {
+        this.aksjonspunkt = aksjonspunkt;
+        this.kriterier = kriterieListeFra(aksjonspunkt);
+    }
+
+    public List<AndreKriterierType> getKriterier() {
+        return kriterier;
+    }
+
+    private List<AndreKriterierType> kriterieListeFra(List<Aksjonspunkt> aksjonspunkt) {
+        List<AndreKriterierType> kriterier = new ArrayList<>();
+
+        if (tilBeslutter()) kriterier.add(AndreKriterierType.TIL_BESLUTTER);
+        if (erRegistrerPapirSøknad()) kriterier.add(AndreKriterierType.PAPIRSØKNAD);
+        if (erUtenlandssak()) kriterier.add(AndreKriterierType.UTLANDSSAK);
+        //if (erSelvstendigEllerFrilans()) kriterier.add(AndreKriterierType.SELVSTENDIG_FRILANSER);
+
+        return kriterier;
+    }
+
+    public List<Aksjonspunkt> getAksjonspunkt() {
+        return aksjonspunkt;
+    }
+
+//    private boolean erSelvstendigEllerFrilans() {
+//        return safeStream(aksjonspunkt).anyMatch(Aksjonspunkt::erSelvstendigEllerFrilanser);
+//    }
+
+    private boolean tilBeslutter() {
+        return safeStream(aksjonspunkt).anyMatch(Aksjonspunkt::tilBeslutter);
+    }
+
+    private boolean erRegistrerPapirSøknad() {
+        return safeStream(aksjonspunkt).anyMatch(Aksjonspunkt::erRegistrerPapirSøknad);
+    }
+
+    private boolean erUtenlandssak() {
+        return safeStream(aksjonspunkt).anyMatch(Aksjonspunkt::erUtenlandssak);
+    }
+}

--- a/kafkatjenester/src/main/java/no/nav/fplos/kafkatjenester/FpsakEvent.java
+++ b/kafkatjenester/src/main/java/no/nav/fplos/kafkatjenester/FpsakEvent.java
@@ -1,0 +1,63 @@
+package no.nav.fplos.kafkatjenester;
+
+import no.nav.foreldrepenger.loslager.oppgave.AndreKriterierType;
+import no.nav.foreldrepenger.loslager.oppgave.OppgaveEventLogg;
+import no.nav.foreldrepenger.loslager.oppgave.OppgaveEventType;
+import no.nav.fplos.foreldrepengerbehandling.Aksjonspunkt;
+import no.nav.fplos.foreldrepengerbehandling.BehandlingFpsak;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static no.nav.fplos.kafkatjenester.util.StreamUtil.safeStream;
+
+public class FpsakEvent {
+    private final FpsakAksjonspunkt fpsakAksjonspunkt;
+    private final OppgaveEventLogg sisteEvent;
+    private final List<AndreKriterierType> andreKriterier = new ArrayList<>();
+    private final String saksbehandlerForTotrinn;
+
+    public FpsakEvent(BehandlingFpsak behandling,
+                      List<OppgaveEventLogg> eventHistorikk,
+                      List<Aksjonspunkt> aksjonspunkt) {
+        this.fpsakAksjonspunkt = new FpsakAksjonspunkt(aksjonspunkt);
+        this.sisteEvent = sisteEventFra(eventHistorikk);
+        this.saksbehandlerForTotrinn = behandling.getAnsvarligSaksbehandler();
+
+        if (harGradering(behandling)) this.andreKriterier.add(AndreKriterierType.SOKT_GRADERING);
+        if (utbetalingTilBruker(behandling)) this.andreKriterier.add(AndreKriterierType.UTBETALING_TIL_BRUKER);
+        andreKriterier.addAll(fpsakAksjonspunkt.getKriterier());
+    }
+
+    public List<AndreKriterierType> getAndreKriterier() {
+        return andreKriterier;
+    }
+
+    public String getSaksbehandlerForTotrinn() {
+        return saksbehandlerForTotrinn;
+    }
+
+    public OppgaveEventLogg getSisteEvent() {
+        return sisteEvent;
+    }
+
+    private OppgaveEventLogg sisteEventFra(List<OppgaveEventLogg> eventHistorikk) {
+        return safeStream(eventHistorikk)
+                .filter(e -> e.getEventType().equals(OppgaveEventType.OPPRETTET))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static boolean utbetalingTilBruker(BehandlingFpsak behandling) {
+        Boolean harRefusjonskrav = behandling.getHarRefusjonskravFraArbeidsgiver();
+        //Skal ikke ha egenskap når harRefusjonskrav er true eller null. Vi avventer inntektsmelding før vi legger på egenskapen.
+        return harRefusjonskrav != null && !harRefusjonskrav;
+    }
+
+    private static boolean harGradering(BehandlingFpsak behandling) {
+        return behandling.getHarGradering() != null && behandling.getHarGradering();
+    }
+
+
+
+}

--- a/kafkatjenester/src/test/java/no/nav/fplos/kafkatjenester/FpsakEventHandlerTest.java
+++ b/kafkatjenester/src/test/java/no/nav/fplos/kafkatjenester/FpsakEventHandlerTest.java
@@ -328,7 +328,7 @@ public class FpsakEventHandlerTest {
 
     private void sjekkForEnOppgaveOgEgenskap(AndreKriterierType egenskap, int antallOppgaver, int antallEgenskaper) {
         assertThat(repoRule.getRepository().hentAlle(Oppgave.class)).hasSize(antallOppgaver);
-        var oegenskaper = repoRule.getRepository().hentAlle(OppgaveEgenskap.class);
+        var oppgaveEgenskaper = repoRule.getRepository().hentAlle(OppgaveEgenskap.class);
         assertThat(repoRule.getRepository().hentAlle(OppgaveEgenskap.class)).hasSize(antallEgenskaper);
         assertThat(repoRule.getRepository().hentAlle(OppgaveEgenskap.class))
                 .extracting(OppgaveEgenskap::getAndreKriterierType).contains(egenskap);

--- a/kafkatjenester/src/test/java/no/nav/fplos/kafkatjenester/TestUtil.java
+++ b/kafkatjenester/src/test/java/no/nav/fplos/kafkatjenester/TestUtil.java
@@ -11,6 +11,8 @@ class TestUtil {
                 .medUuid(UUID.nameUUIDFromBytes("TEST".getBytes()))
                 .medBehandlendeEnhetNavn("NAV")
                 .medAnsvarligSaksbehandler("VLLOS")
-                .medStatus("-");
+                .medStatus("-")
+                .medHarGradering(null)
+                .medHarRefusjonskrav(null);
     }
 }


### PR DESCRIPTION
Wrapper aksjonspunkt i ny klasse som håndterer kriterier for opprettelse av OppgaveEgenskaper

Gjenstår:
- bedre test av totrinnsbehandling saksbehandler (spesielt gjenåpning av eksisterende kriterie etter ny saksbehandler)
- sjekk/fjern logikk fra admintjenestene for oppgavesynkronisering i bulk. Tjenestene for å legge på oppgaveegenskaper har ikke vært brukt pga sannsynlig påvirkning på statistikk. Dersom man skriver om statistikkmodulen kan det være en bedre løsning å erstatte med en enkelt tjeneste som gjør full synkronisering av oppgaveegenskaper.