### PR TITLE
Legger på AD grupper som kan kreve OBO tokens fra fplos

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -12,9 +12,14 @@
   "minReplica": "1",
   "maxReplica": "2",
   "env": {
-    "APPDYNAMICS_AGENT_ACCOUNT_NAME": "NON-PROD",
     "APPD_ENABLED": "false"
   },
+  "groups": [
+    "27e77109-fef2-48ce-a174-269074490353",
+    "8cddda87-0a22-4d35-9186-a2c32a6ab450",
+    "e6508a2a-2e74-450e-ad24-eb1b2b4625c6",
+    "f1b82579-c5b5-4617-9673-8ace5ff67f63"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -57,7 +57,7 @@ spec:
       - kvPath: /apikey/appdynamics/{{environment}}
         mountPath: /var/run/secrets/nais.io/appdynamics
   env:
-{{#each env}}
+  {{#each env}}
    - name: {{@key}}
      value: "{{this}}"
   {{/each}}
@@ -68,20 +68,24 @@ spec:
         extra:
           - "NAVident"
           - "azp_name"
+        groups:
+          {{#each groups as |group|}}
+          - id: "{{group}}"
+          {{/each}}
   {{#if AZURE_IAC_RULES}}
   accessPolicy:
-      inbound:
-        rules:
-        {{#each AZURE_IAC_RULES}}
-           - application: {{app}}
-             namespace: {{namespace}}
-             cluster: {{cluster}}
-             {{#if scopes}}
-             permissions:
-                scopes:
-                {{#each scopes}}
-                - "{{this}}"
-                {{/each}}
-             {{/if}}
-        {{/each}}
+    inbound:
+      rules:
+      {{#each AZURE_IAC_RULES}}
+        - application: {{app}}
+          namespace: {{namespace}}
+          cluster: {{cluster}}
+          {{#if scopes}}
+          permissions:
+            scopes:
+            {{#each scopes}}
+            - "{{this}}"
+            {{/each}}
+          {{/if}}
+      {{/each}}
   {{/if}}

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -12,9 +12,14 @@
   "minReplica": "2",
   "maxReplica": "3",
   "env": {
-    "APPDYNAMICS_AGENT_ACCOUNT_NAME": "PROD",
     "APPD_ENABLED": "true"
   },
+  "groups": [
+    "73107205-17ec-4a07-a56e-e0a8542f90c9",
+    "77f05833-ebfd-45fb-8be7-88eca8e7418f",
+    "1a59da27-4c55-4a9d-8480-6abd1a856cd2",
+    "0d226374-4748-4367-a38a-062dcad70034"
+  ],
   "AZURE_IAC_RULES": [
     {
       "app": "fp-swagger",

--- a/README.md
+++ b/README.md
@@ -22,10 +22,18 @@ docker build -t fplos .
 docker run -d --env-file=docker.list --name fplos fplos
 ```
 
-
 ## Kjøring lokalt
-
 
 `no.nav.foreldrepenger.los.web.server.jetty.JettyDevServer` started i Intellij. Lokalt så går den mot Virtuell Tjenesteplattform. Denne må selvsagt kjøre på 
 standard porter. Merk du trenger trolig sertifikater om applikasjonen bruker tjenester
 på soap. Dette er pga WS-secure, etc.
+
+### Sikkerhet
+Det er mulig å kalle tjenesten med bruk av følgende tokens
+- Azure CC
+- Azure OBO med følgende rettigheter:
+    - fpsak-saksbehandler
+    - fpsak-veileder
+    - fpsak-oppgavestyrer
+    - fpsak-drift
+- STS (fases ut)

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -41,8 +41,6 @@ task.manager.polling.wait=5
 task.manager.polling.delay=5
 task.manager.polling.tasks.size=1
 
-fpsak.frontend.url=http://localhost:9000/fpsak
-
 axsys.enabled=false
 
 # Database


### PR DESCRIPTION
Enforcet endring av NAIS https://nav-it.slack.com/archives/C01DE3M9YBV/p1674475818557619

Per i dag er det brukere fra følgende azure grupper som får lov å kommunisere med fpsak med en OBO:
- fpsak-saksbehandler
- fpsak-veileder
- fpsak-oppgavestyrer
- fpsak-drift (swagger)