### PR TITLE
Vurder EØS-egenskap kun ved aktivt aksjonspunkt

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/los/klient/fpsak/Aksjonspunkt.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/los/klient/fpsak/Aksjonspunkt.java
@@ -34,6 +34,17 @@ public class Aksjonspunkt {
         // Jackson
     }
 
+    public Aksjonspunkt(String definisjonKode, String statusKode, String begrunnelse) {
+        this(definisjonKode, statusKode, begrunnelse, null);
+    }
+
+    public Aksjonspunkt(String definisjonKode, String statusKode, String begrunnelse, LocalDateTime fristTid) {
+        this.definisjonKode = definisjonKode;
+        this.statusKode = statusKode;
+        this.begrunnelse = begrunnelse;
+        this.fristTid = fristTid;
+    }
+
     public String getBegrunnelse() {
         return begrunnelse;
     }
@@ -75,7 +86,7 @@ public class Aksjonspunkt {
     }
 
     public boolean skalVurdereInnhentingAvSED() {
-        return !erAvbrutt() && AUTOMATISK_MARKERING_SOM_UTLAND.equals(definisjonKode);
+        return erAktiv() && AUTOMATISK_MARKERING_SOM_UTLAND.equals(definisjonKode);
     }
 
     public boolean erManueltOverstyrtTilUtenlandssak() {


### PR DESCRIPTION
Ønsker at egenskapen skal opphøre når aksjonspunkt er løst. Likevel ikke aktuell egenskap dersom allerede overstyrt til/markert som nasjonal. 

Flytter utredelse av egenskapen til aksjonspunkt.