### PR TITLE
Ikke randomiser små køer

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/los/web/app/tjenester/felles/dto/OppgaveDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/los/web/app/tjenester/felles/dto/OppgaveDtoTjeneste.java
@@ -128,7 +128,7 @@ public class OppgaveDtoTjeneste {
 
     public List<OppgaveDto> getOppgaverTilBehandling(Long sakslisteId) {
         var nesteOppgaver = oppgaveKøTjeneste.hentOppgaver(sakslisteId, ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER * 7);
-        var oppgaveDtos = map(nesteOppgaver, ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER, true);
+        var oppgaveDtos = map(nesteOppgaver, ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER, nesteOppgaver.size() == ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER * 7);
         //Noen oppgave filteres bort i mappingen pga at saksbehandler ikke har tilgang til behandlingen
         if (oppgaveDtos.size() == Math.min(ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER, nesteOppgaver.size())) {
             return oppgaveDtos;


### PR DESCRIPTION
Bruker kun randomisering dersom spørring gir max antall (21 eller flere) oppgaver.
På den annen siden vil en del F5 bla gjennom køen ....