### PR TITLE
Bedre håndtering retur beslutter

### DIFF
--- a/domene/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/fpsak/FpsakOppgaveEgenskapFinner.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/fpsak/FpsakOppgaveEgenskapFinner.java
@@ -64,6 +64,7 @@ public class FpsakOppgaveEgenskapFinner implements OppgaveEgenskapFinner {
         }
         var aksjonspunkter = behandling.aksjonspunkt().stream().map(Aksjonspunkt::aksjonspunktFra).toList();
 
+        // Ved behov ta med  && !matchAksjonspunkt(aksjonspunkter, Aksjonspunkt::erForeslåVedtak)
         if (matchAksjonspunkt(aksjonspunkter, Aksjonspunkt::erTilBeslutter)) {
             this.andreKriterier.add(AndreKriterierType.TIL_BESLUTTER);
         }

--- a/domene/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/tilbakekreving/TilbakekrevingOppgaveEgenskapFinner.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/tilbakekreving/TilbakekrevingOppgaveEgenskapFinner.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.tilbakekreving;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.FagsakEgenskaper;
 import no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.OppgaveEgenskapFinner;
@@ -33,7 +34,8 @@ public class TilbakekrevingOppgaveEgenskapFinner implements OppgaveEgenskapFinne
         if (FagsakEgenskaper.fagsakErMarkertNæring(egenskaperDto)) {
             this.andreKriterier.add(AndreKriterierType.NÆRING);
         }
-        if (aksjonspunkter.stream().anyMatch(a -> a.definisjon().equals("5005") && Aksjonspunktstatus.OPPRETTET.equals(a.status()))) {
+        if (aksjonspunkter.stream().anyMatch(a -> a.definisjon().equals("5005") && Aksjonspunktstatus.OPPRETTET.equals(a.status())) &&
+            aksjonspunkter.stream().noneMatch(a -> !Set.of("5005","7001","7002").contains(a.definisjon()) && Aksjonspunktstatus.OPPRETTET.equals(a.status()))) {
             this.andreKriterier.add(AndreKriterierType.TIL_BESLUTTER);
         }
         this.saksbehandlerForTotrinn = saksbehandler;

--- a/domene/src/main/java/no/nav/foreldrepenger/los/klient/fpsak/Aksjonspunkt.java
+++ b/domene/src/main/java/no/nav/foreldrepenger/los/klient/fpsak/Aksjonspunkt.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.asList;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 import no.nav.vedtak.hendelser.behandling.Aksjonspunktstatus;
 import no.nav.vedtak.hendelser.behandling.los.LosBehandlingDto;
@@ -15,6 +16,7 @@ public class Aksjonspunkt {
 
     public static final String MANUELT_SATT_PÅ_VENT_KODE = "7001";
     public static final String PÅ_VENT_KODEGRUPPE_STARTS_WITH = "7";
+    public static final Set<String> FORESLÅ_VEDTAK_KODE = Set.of("5015", "5018", "5028");
     public static final String TIL_BESLUTTER_KODE = "5016";
     protected static final List<String> REGISTRER_PAPIRSØKNAD_KODE = asList("5012", "5040", "5057", "5096");
     protected static final List<String> VURDER_FORMKRAV_GRUPPE = List.of("5082");
@@ -72,6 +74,10 @@ public class Aksjonspunkt {
 
     public boolean erTilBeslutter() {
         return TIL_BESLUTTER_KODE.equals(definisjonKode) && erAktiv();
+    }
+
+    public boolean erForeslåVedtak() {
+        return FORESLÅ_VEDTAK_KODE.contains(definisjonKode) && erAktiv();
     }
 
     public boolean erRegistrerPapirSøknad() {


### PR DESCRIPTION
Fra Teams:  Ser at når jeg returnererer T-sak (som beslutter) tilbake til saksbehandler, så ligger fortsatt saken på min benk i VL. Ser ikke ut som om saken går tilbake til saksbehandler/benken for behandling. 

Det er flere ting - det er returnert til Foreslå Vedtak og både aksjonspunkt Foreslå + Fatte er åpne. Gir TIL_BESLUTTER feilaktig.
Håndtering av statuser er mer likt FPSAK sin TransisjonUtleder.

Usikker på om retur til Foreslå i FPSAK beholder aksjonspunkt 5015 åpent. 