### PR TITLE
Legger til task for å fjerne gamle innslag i køstatistikk-tabellen (TFP-5590)

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkRepository.java
@@ -45,36 +45,39 @@ public class KøStatistikkRepository {
     }
 
     public List<NyeOgFerdigstilteOppgaver> hentStatistikk(Long oppgaveFilterSettId) {
-        final var tellesSomFerdigstilt = Stream.of(
-            KøOppgaveHendelse.LUKKET_OPPGAVE, KøOppgaveHendelse.UT_TIL_ANNEN_KØ, KøOppgaveHendelse.OPPGAVE_SATT_PÅ_VENT).map(KøOppgaveHendelse::name).toList();
+        final var tellesSomFerdigstilt = Stream.of(KøOppgaveHendelse.LUKKET_OPPGAVE, KøOppgaveHendelse.UT_TIL_ANNEN_KØ,
+            KøOppgaveHendelse.OPPGAVE_SATT_PÅ_VENT).map(KøOppgaveHendelse::name).toList();
         var query = entityManager.createNativeQuery("""
-            with cte as (
-                select distinct
-                trunc(kø.opprettet_tid) as dato,
-                kø.behandling_type,
-                case when kø.hendelse in :tellesSomFerdigstilt
-                    then 'ferdigstilte'
-                    else 'nye'
-                end as res,
-                o.behandling_id as behandling_id
-                FROM STATISTIKK_KO kø
-                join oppgave o on o.id = kø.oppgave_id
-                WHERE kø.OPPGAVE_FILTRERING_ID = :oppgaveFilterSettId
-                AND kø.OPPRETTET_TID >= to_timestamp(current_date - interval '7' day)
-            )
-            select dato, behandling_type,
-            count(case when res = 'nye' then 1 end) nye,
-            count(case when res = 'ferdigstilte' then 1 end) ferdigstilte
-            from cte
-            group by dato, behandling_type
-            """).setParameter("oppgaveFilterSettId", oppgaveFilterSettId).setParameter("tellesSomFerdigstilt", tellesSomFerdigstilt);
+                with cte as (
+                    select distinct
+                    trunc(kø.opprettet_tid) as dato,
+                    kø.behandling_type,
+                    case when kø.hendelse in :tellesSomFerdigstilt
+                        then 'ferdigstilte'
+                        else 'nye'
+                    end as res,
+                    o.behandling_id as behandling_id
+                    FROM STATISTIKK_KO kø
+                    join oppgave o on o.id = kø.oppgave_id
+                    WHERE kø.OPPGAVE_FILTRERING_ID = :oppgaveFilterSettId
+                    AND kø.OPPRETTET_TID >= :opprettetEtter
+                )
+                select dato, behandling_type,
+                count(case when res = 'nye' then 1 end) nye,
+                count(case when res = 'ferdigstilte' then 1 end) ferdigstilte
+                from cte
+                group by dato, behandling_type
+                """)
+            .setParameter("oppgaveFilterSettId", oppgaveFilterSettId)
+            .setParameter("tellesSomFerdigstilt", tellesSomFerdigstilt)
+            .setParameter("opprettetEtter", LocalDate.now().minusDays(7).atStartOfDay());
         @SuppressWarnings("unchecked") var result = query.getResultStream().map(KøStatistikkRepository::map).toList();
         return result;
     }
 
     int slettUtdaterte() {
-        var query = entityManager.createNativeQuery("delete from STATISTIKK_KO where opprettet_tid < :ts")
-            .setParameter("ts", LocalDateTime.now().minusDays(30));
+        var query = entityManager.createNativeQuery("delete from STATISTIKK_KO where opprettet_tid < :opprettetForutFor")
+            .setParameter("opprettetForutFor", LocalDate.now().minusDays(7).atStartOfDay());
         int deletedRows = query.executeUpdate();
         entityManager.flush();
         return deletedRows;

--- a/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkRepository.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.los.statistikk.kø;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -69,6 +70,14 @@ public class KøStatistikkRepository {
             """).setParameter("oppgaveFilterSettId", oppgaveFilterSettId).setParameter("tellesSomFerdigstilt", tellesSomFerdigstilt);
         @SuppressWarnings("unchecked") var result = query.getResultStream().map(KøStatistikkRepository::map).toList();
         return result;
+    }
+
+    int slettUtdaterte() {
+        var query = entityManager.createNativeQuery("delete from STATISTIKK_KO where opprettet_tid < :ts")
+            .setParameter("ts", LocalDateTime.now().minusDays(30));
+        int deletedRows = query.executeUpdate();
+        entityManager.flush();
+        return deletedRows;
     }
 
     private static NyeOgFerdigstilteOppgaver map(Object objectArray) {

--- a/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/SlettUtdatertKoStatistikkTask.java
+++ b/src/main/java/no/nav/foreldrepenger/los/statistikk/kø/SlettUtdatertKoStatistikkTask.java
@@ -1,0 +1,29 @@
+package no.nav.foreldrepenger.los.statistikk.kø;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Dependent
+@ProsessTask(value = "vedlikehold.kostatistikk", cronExpression = "0 16 1 * * *", maxFailedRuns = 1)
+public class SlettUtdatertKoStatistikkTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlettUtdatertKoStatistikkTask.class);
+    private final KøStatistikkRepository køStatistikkRepository;
+
+    @Inject
+    public SlettUtdatertKoStatistikkTask(KøStatistikkRepository køStatistikkRepository) {
+        this.køStatistikkRepository = køStatistikkRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var slettet = køStatistikkRepository.slettUtdaterte();
+        LOG.info("Slettet {} rader i køstatistikk-tabellen", slettet);
+    }
+}


### PR DESCRIPTION
Første kjøring er på 4 millioner rader - bør dba gjøre den eller er det problemfritt å la appen gjøre det?

Det er index på opprettet_tid-kolonnen.

La ikke på noen test her, men kjørt lokalt ok.