### PR TITLE
Støtte for slette av avdeling og inaktive saksbehandlere (TFP-5612) (TFP-5686)

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepository.java
@@ -56,6 +56,23 @@ public class OrganisasjonRepository {
             """, Saksbehandler.class).setParameter("ident", saksbehandlerIdent.toUpperCase());
     }
 
+    public void slettSaksbehandlereUtenKnytninger() {
+        int slettedeRader = entityManager.createQuery("""
+                delete from saksbehandler s
+                where not exists (
+                    select ofil
+                    from OppgaveFiltrering ofil
+                    where s member of ofil.saksbehandlere
+                )
+                and not exists (
+                    select avd
+                    from avdeling avd
+                    where s member of avd.saksbehandlere
+                )""")
+            .executeUpdate();
+        LOG.info("Slettet {} saksbehandlere uten knytninger til køer", slettedeRader);
+    }
+
     public Optional<Avdeling> hentAvdelingFraEnhet(String avdelingEnhet) {
         var query = entityManager.createQuery("FROM avdeling a WHERE a.avdelingEnhet = :avdelingEnhet", Avdeling.class)
             .setParameter("avdelingEnhet", avdelingEnhet);

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/AdminRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/AdminRestTjeneste.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
@@ -94,6 +95,15 @@ public class AdminRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT)
     public Response deaktiverAvdeling(@NotNull @Valid DriftAvdelingEnhetDto avdelingEnhetDto) {
         organisasjonRepository.deaktiverAvdeling(avdelingEnhetDto.avdelingEnhet());
+        return Response.ok().build();
+    }
+
+    @DELETE
+    @Path("/slett-saksbehandlere")
+    @Operation(description = "Sletter saksbehandlere uten knytning til køer eller avdeling", tags = "admin")
+    @BeskyttetRessurs(actionType = ActionType.DELETE, resourceType = ResourceType.DRIFT)
+    public Response slettSaksbehandlereUtenKnytninger() {
+        organisasjonRepository.slettSaksbehandlereUtenKnytninger();
         return Response.ok().build();
     }
 

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTask.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTask.java
@@ -1,0 +1,67 @@
+package no.nav.foreldrepenger.los.tjenester.admin;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.los.avdelingsleder.AvdelingslederSaksbehandlerTjeneste;
+import no.nav.foreldrepenger.los.avdelingsleder.AvdelingslederTjeneste;
+import no.nav.foreldrepenger.los.oppgave.OppgaveRepository;
+import no.nav.foreldrepenger.los.oppgavekø.OppgaveFiltrering;
+import no.nav.foreldrepenger.los.organisasjon.OrganisasjonRepository;
+import no.nav.foreldrepenger.los.organisasjon.SaksbehandlerGruppe;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@Dependent
+@ProsessTask(value = "vedlikehold.slettavdeling", maxFailedRuns = 1)
+public class SlettDeaktiverteAvdelingerTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlettDeaktiverteAvdelingerTask.class);
+    private final OrganisasjonRepository organisasjonsRepository;
+    private final AvdelingslederTjeneste avdelingslederTjeneste;
+    private final AvdelingslederSaksbehandlerTjeneste avdelingslederSaksbehandlerTjeneste;
+    private OppgaveRepository oppgaveRepository;
+
+    @Inject
+    public SlettDeaktiverteAvdelingerTask(OppgaveRepository oppgaveRepository,
+                                          OrganisasjonRepository organisasjonRepository,
+                                          AvdelingslederTjeneste avdelingslederTjeneste,
+                                          AvdelingslederSaksbehandlerTjeneste avdelingslederSaksbehandlerTjeneste) {
+        this.oppgaveRepository = oppgaveRepository;
+        this.organisasjonsRepository = organisasjonRepository;
+        this.avdelingslederTjeneste = avdelingslederTjeneste;
+        this.avdelingslederSaksbehandlerTjeneste = avdelingslederSaksbehandlerTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var enhetsnummer = prosessTaskData.getPropertyValue("enhetsnummer");
+
+        var avdeling = organisasjonsRepository.hentAvdelingFraEnhet(enhetsnummer).orElse(null);
+        if (avdeling == null || avdeling.getErAktiv()) {
+            LOG.info("Fant ikke inaktiv enhet {}, avslutter.", enhetsnummer);
+            return;
+        }
+
+        var antallÅpneOppgaver = oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getId());
+        if (antallÅpneOppgaver > 0) {
+            LOG.warn("Fant {} aktive oppgaver tilknyttet enhetsnummer {}, avbryter avdelingssletting.", antallÅpneOppgaver, enhetsnummer);
+            return;
+        }
+
+        var grupper = avdelingslederSaksbehandlerTjeneste.hentAvdelingensSaksbehandlereOgGrupper(enhetsnummer)
+            .stream().map(SaksbehandlerGruppe::getId).toList();
+        LOG.info("Sletter {} saksbehandlergrupper tilknyttet enhet {}", grupper.size(), enhetsnummer);
+        grupper.forEach(g -> avdelingslederSaksbehandlerTjeneste.slettSaksbehandlerGruppe(g, enhetsnummer));
+
+        var køer = avdeling.getOppgaveFiltrering().stream().map(OppgaveFiltrering::getId).toList();
+        LOG.info("Sletter {} køer tilknyttet enhet {}", køer.size(), enhetsnummer);
+        køer.forEach(avdelingslederTjeneste::slettOppgaveFiltrering);
+
+        organisasjonsRepository.slettAvdeling(avdeling);
+        LOG.info("Slettet enhet {}", enhetsnummer);
+    }
+}

--- a/src/test/java/no/nav/foreldrepenger/los/DBTestUtil.java
+++ b/src/test/java/no/nav/foreldrepenger/los/DBTestUtil.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.los;
 
+import static no.nav.foreldrepenger.los.organisasjon.Avdeling.AVDELING_DRAMMEN_ENHET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Comparator;
@@ -9,6 +10,7 @@ import java.util.stream.Collectors;
 import jakarta.persistence.EntityManager;
 
 import no.nav.foreldrepenger.los.felles.BaseEntitet;
+import no.nav.foreldrepenger.los.organisasjon.Avdeling;
 
 public final class DBTestUtil {
 
@@ -25,6 +27,14 @@ public final class DBTestUtil {
         var entiteter = hentAlle(entityManager, klasse);
         assertThat(entiteter).hasSize(1);
         return entiteter.get(0);
+    }
+
+    public static Avdeling avdelingDrammen(EntityManager entityManager) {
+        return hentAlle(entityManager, Avdeling.class)
+            .stream()
+            .filter(a -> a.getAvdelingEnhet().equals(AVDELING_DRAMMEN_ENHET))
+            .findAny()
+            .orElseThrow();
     }
 
 }

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.los.oppgave;
 
+import static no.nav.foreldrepenger.los.DBTestUtil.avdelingDrammen;
 import static no.nav.foreldrepenger.los.oppgavekø.KøSortering.BEHANDLINGSFRIST;
 import static no.nav.foreldrepenger.los.oppgavekø.KøSortering.FEILUTBETALINGSTART;
 import static no.nav.foreldrepenger.los.organisasjon.Avdeling.AVDELING_DRAMMEN_ENHET;
@@ -30,7 +31,6 @@ import no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.oppgaveeventlogg.Op
 import no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.oppgaveeventlogg.OppgaveEventType;
 import no.nav.foreldrepenger.los.oppgavekø.KøSortering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveFiltrering;
-import no.nav.foreldrepenger.los.organisasjon.Avdeling;
 import no.nav.foreldrepenger.los.reservasjon.ReservasjonTjeneste;
 
 @ExtendWith(JpaExtension.class)
@@ -68,15 +68,7 @@ class OppgaveRepositoryTest {
     }
 
     private Long avdelingIdForDrammen() {
-        return avdelingForDrammen().getId();
-    }
-
-    private Avdeling avdelingForDrammen() {
-        return DBTestUtil.hentAlle(entityManager, Avdeling.class)
-                         .stream()
-                         .filter(a -> a.getAvdelingEnhet().equals(AVDELING_DRAMMEN_ENHET))
-                         .findAny()
-                         .orElseThrow();
+        return avdelingDrammen(entityManager).getId();
     }
 
     @Test
@@ -253,7 +245,7 @@ class OppgaveRepositoryTest {
 
     @Test
     void hentAlleLister() {
-        var avdeling = avdelingForDrammen();
+        var avdeling = avdelingDrammen(entityManager);
         var førsteOppgaveFiltrering = OppgaveFiltrering.builder()
             .medNavn("OPPRETTET")
             .medSortering(KøSortering.OPPRETT_BEHANDLING)

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.los.oppgave;
 
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static no.nav.foreldrepenger.los.DBTestUtil.avdelingDrammen;
 import static no.nav.foreldrepenger.los.organisasjon.Avdeling.AVDELING_DRAMMEN_ENHET;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -16,12 +17,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import no.nav.foreldrepenger.los.JpaExtension;
-import no.nav.foreldrepenger.los.DBTestUtil;
 import no.nav.foreldrepenger.los.avdelingsleder.AvdelingslederTjeneste;
 import no.nav.foreldrepenger.los.oppgavekø.KøSortering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveFiltrering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveKøTjeneste;
-import no.nav.foreldrepenger.los.organisasjon.Avdeling;
 import no.nav.foreldrepenger.los.organisasjon.OrganisasjonRepository;
 import no.nav.foreldrepenger.los.reservasjon.ReservasjonRepository;
 import no.nav.foreldrepenger.los.reservasjon.ReservasjonTjeneste;
@@ -68,7 +67,7 @@ class OppgaveTjenesteTest {
         var oppgaveFiltrering = OppgaveFiltrering.builder()
             .medNavn("OPPRETTET")
             .medSortering(KøSortering.OPPRETT_BEHANDLING)
-            .medAvdeling(avdelingDrammen())
+            .medAvdeling(avdelingDrammen(entityManager))
             .build();
         oppgaveRepository.lagre(oppgaveFiltrering);
         oppgaveRepository.lagre(førstegangOppgave);
@@ -77,14 +76,6 @@ class OppgaveTjenesteTest {
         oppgaveRepository.lagre(førstegangOppgaveBergen);
         entityManager.refresh(oppgaveFiltrering);
         return oppgaveFiltrering.getId();
-    }
-
-    private Avdeling avdelingDrammen() {
-        return DBTestUtil.hentAlle(entityManager, Avdeling.class)
-            .stream()
-            .filter(a -> a.getAvdelingEnhet().equals(AVDELING_DRAMMEN_ENHET))
-            .findAny()
-            .orElseThrow();
     }
 
     @Test
@@ -105,7 +96,7 @@ class OppgaveTjenesteTest {
         var opprettet = OppgaveFiltrering.builder()
             .medNavn("OPPRETTET")
             .medSortering(KøSortering.OPPRETT_BEHANDLING)
-            .medAvdeling(avdelingDrammen())
+            .medAvdeling(avdelingDrammen(entityManager))
             .build();
         oppgaveRepository.lagre(opprettet);
 
@@ -120,7 +111,7 @@ class OppgaveTjenesteTest {
         var tredjeOppgave = opprettOgLargeOppgaveTilSortering(9, 8, 10);
         var fjerdeOppgave = opprettOgLargeOppgaveTilSortering(10, 0, 9);
 
-        var frist = OppgaveFiltrering.builder().medNavn("FRIST").medSortering(KøSortering.BEHANDLINGSFRIST).medAvdeling(avdelingDrammen()).build();
+        var frist = OppgaveFiltrering.builder().medNavn("FRIST").medSortering(KøSortering.BEHANDLINGSFRIST).medAvdeling(avdelingDrammen(entityManager)).build();
         oppgaveRepository.lagre(frist);
 
         var oppgaves = oppgaveKøTjeneste.hentOppgaver(frist.getId());
@@ -137,7 +128,7 @@ class OppgaveTjenesteTest {
         var førsteStønadsdag = OppgaveFiltrering.builder()
             .medNavn("STØNADSDAG")
             .medSortering(KøSortering.FØRSTE_STØNADSDAG)
-            .medAvdeling(avdelingDrammen())
+            .medAvdeling(avdelingDrammen(entityManager))
             .build();
         oppgaveRepository.lagre(førsteStønadsdag);
 

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.los.oppgave.kø;
 
 
+import static no.nav.foreldrepenger.los.DBTestUtil.avdelingDrammen;
 import static no.nav.foreldrepenger.los.organisasjon.Avdeling.AVDELING_DRAMMEN_ENHET;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,7 +10,6 @@ import java.util.List;
 
 import jakarta.persistence.EntityManager;
 
-import no.nav.foreldrepenger.los.DBTestUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +24,6 @@ import no.nav.foreldrepenger.los.oppgave.OppgaveRepository;
 import no.nav.foreldrepenger.los.oppgavekø.KøSortering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveFiltrering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveKøTjeneste;
-import no.nav.foreldrepenger.los.organisasjon.Avdeling;
 import no.nav.foreldrepenger.los.organisasjon.OrganisasjonRepository;
 import no.nav.foreldrepenger.los.organisasjon.Saksbehandler;
 
@@ -120,7 +119,7 @@ class OppgaveKøTjenesteTest {
         var oppgaveFiltrering = OppgaveFiltrering.builder()
             .medNavn("OPPRETTET")
             .medSortering(KøSortering.OPPRETT_BEHANDLING)
-            .medAvdeling(avdelingDrammen())
+            .medAvdeling(avdelingDrammen(entityManager))
             .build();
         oppgaveRepository.lagre(oppgaveFiltrering);
         leggtilOppgaveMedEkstraEgenskaper(førstegangOppgave, AndreKriterierType.TIL_BESLUTTER);
@@ -144,7 +143,7 @@ class OppgaveKøTjenesteTest {
             var oppgaveFiltrering = OppgaveFiltrering.builder()
                 .medNavn("Test " + i)
                 .medSortering(KøSortering.BEHANDLINGSFRIST)
-                .medAvdeling(avdelingDrammen())
+                .medAvdeling(avdelingDrammen(entityManager))
                 .build();
             entityManager.persist(oppgaveFiltrering);
             filtre.add(oppgaveFiltrering);
@@ -158,7 +157,7 @@ class OppgaveKøTjenesteTest {
         var oppgaveFiltrering = OppgaveFiltrering.builder()
             .medNavn("OPPRETTET")
             .medSortering(KøSortering.OPPRETT_BEHANDLING)
-            .medAvdeling(avdelingDrammen())
+            .medAvdeling(avdelingDrammen(entityManager))
             .build();
         oppgaveRepository.lagre(oppgaveFiltrering);
         oppgaveRepository.lagre(førstegangOppgave);
@@ -169,11 +168,5 @@ class OppgaveKøTjenesteTest {
         return oppgaveFiltrering.getId();
     }
 
-    private Avdeling avdelingDrammen() {
-        return DBTestUtil.hentAlle(entityManager, Avdeling.class)
-                         .stream()
-                         .filter(a -> a.getAvdelingEnhet().equals(AVDELING_DRAMMEN_ENHET))
-                         .findAny()
-                         .orElseThrow();
-    }
+
 }

--- a/src/test/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepositoryTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static no.nav.foreldrepenger.los.DBTestUtil.avdelingDrammen;
+import static no.nav.foreldrepenger.los.DBTestUtil.hentAlle;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,4 +37,23 @@ class OrganisasjonRepositoryTest {
         assertThat(avdelinger).contains(enhetsNummer);
         assertThat(etterDeaktiver).isNotEmpty().doesNotContain(enhetsNummer);
     }
+
+    @Test
+    void skalSletteSaksbehandlereUtenKnytninger() {
+        var saksbehandlerUtenKnytning = new Saksbehandler("ikke-knyttet");
+        entityManager.persist(saksbehandlerUtenKnytning);
+
+        var saksbehandlerMedKnytning = new Saksbehandler("knyttet");
+        saksbehandlerMedKnytning.leggTilAvdeling(avdelingDrammen(entityManager));
+        entityManager.persist(saksbehandlerMedKnytning);
+        entityManager.flush();
+
+        repository.slettSaksbehandlereUtenKnytninger();
+
+        var saksbehandlereEtterSletting = hentAlle(entityManager, Saksbehandler.class);
+        assertThat(saksbehandlereEtterSletting)
+            .hasSize(1)
+            .first().extracting(Saksbehandler::getSaksbehandlerIdent).isEqualTo("knyttet");
+    }
+
 }

--- a/src/test/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/statistikk/kø/KøStatistikkTjenesteTest.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.los.statistikk.kø;
 
+import static no.nav.foreldrepenger.los.DBTestUtil.avdelingDrammen;
 import static no.nav.foreldrepenger.los.organisasjon.Avdeling.AVDELING_DRAMMEN_ENHET;
 
 import java.time.LocalDate;
@@ -53,7 +54,7 @@ class KøStatistikkTjenesteTest {
 
     @Test
     void skalFinneStatistikkPåKøerSomMatcherOppgave() {
-        var avdeling = avdelingForDrammen();
+        var avdeling = avdelingDrammen(entityManager);
         var oppgave = Oppgave.builder().dummyOppgave(avdeling.getAvdelingEnhet()).build();
         var egenskap = new OppgaveEgenskap(oppgave, AndreKriterierType.BERØRT_BEHANDLING);
         var køMedTreff = kø(avdeling);
@@ -79,14 +80,6 @@ class KøStatistikkTjenesteTest {
 
     private OppgaveFiltrering kø(Avdeling avdeling) {
         return OppgaveFiltrering.builder().medNavn("OPPRETTET").medSortering(KøSortering.OPPRETT_BEHANDLING).medAvdeling(avdeling).build();
-    }
-
-    private Avdeling avdelingForDrammen() {
-        return DBTestUtil.hentAlle(entityManager, Avdeling.class)
-                         .stream()
-                         .filter(a -> a.getAvdelingEnhet().equals(AVDELING_DRAMMEN_ENHET))
-                         .findAny()
-                         .orElseThrow();
     }
 
 }


### PR DESCRIPTION
Fortsetter TFP-5612 (deaktivering/sletting avdeling). Tidligere har vi lagt til deaktivering. Denne delen sletter deaktivert avdeling. Kunne sikkert ha gjort deaktivering+sletting av avdeling i samme task men kanskje greit nok med sikkerhet i to steg. Task sjekker om det ligger aktive oppgaver på enheten før sletting gjennomføres.

TFP-5686 (søppeltømming saksbehandlere): Det er 79 inaktive saksbehandlere (saksbehandlere uten knytninger til avdelinger og køer) i prod pt. Dette inkluderer ikke veilederroller e.l som åpner LOS i dag, den tilgangen kommer gjennom ordinær tilgangskontroll i abac.

For begge disse fortsatte bruk av eksisterende tjenester uten omstrukturering av entiteter. For begge disse og køer kan man antakelig legge på en cascade på delete med orphanremoval som kan forenkle søppeltømmingen. Persist cascade kan sikkert også være gunstig for å rydde opp i manuelle persists i kodebasen. Jeg lar det være en ren refaktorering for å beholde oversikten.
Søppeltømming saksbehandlere bruker JPQL med subqueries.

