### PR TITLE
Forbedret SisteReserverte query

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonRepository.java
@@ -30,18 +30,18 @@ public class ReservasjonRepository {
                 select o from Oppgave o
                 inner join Reservasjon r on r.oppgave = o
                 where r.opprettetTidspunkt > :fom
-                and upper(r.reservertAv) = upper(:uid)
+                and r.reservertAv = :uid
                 and not exists(
                     select 1
                     from Oppgave o2
                     inner join Reservasjon r2 on r2.oppgave = o2
                     where o2.behandlingId = o.behandlingId
                     and o2.opprettetTidspunkt > o.opprettetTidspunkt
-                    and upper(r2.reservertAv) = upper(:uid)
+                    and r2.reservertAv = :uid
                 )
                 order by coalesce(r.endretTidspunkt, r.opprettetTidspunkt) desc
                 """, Oppgave.class) //$NON-NLS-1$
-            .setParameter("uid", uid)
+            .setParameter("uid", uid.toUpperCase())
             .setParameter("fom", fom)
             .setMaxResults(15)
             .getResultList();

--- a/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonRepository.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.los.reservasjon;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -24,21 +25,26 @@ public class ReservasjonRepository {
     }
 
     public List<Oppgave> hentSaksbehandlersSisteReserverteOppgaver(String uid) {
+        var fom = LocalDate.now().minusWeeks(3).atStartOfDay();
         return entityManager.createQuery("""
                 select o from Oppgave o
                 inner join Reservasjon r on r.oppgave = o
-                where upper(r.reservertAv) = upper( :uid )
+                where r.opprettetTidspunkt > :fom
+                and upper(r.reservertAv) = upper(:uid)
                 and not exists(
                     select 1
                     from Oppgave o2
                     inner join Reservasjon r2 on r2.oppgave = o2
                     where o2.behandlingId = o.behandlingId
                     and o2.opprettetTidspunkt > o.opprettetTidspunkt
-                    and upper(r2.reservertAv) = upper( :uid )
+                    and upper(r2.reservertAv) = upper(:uid)
                 )
                 order by coalesce(r.endretTidspunkt, r.opprettetTidspunkt) desc
                 """, Oppgave.class) //$NON-NLS-1$
-            .setParameter("uid", uid).setMaxResults(15).getResultList();
+            .setParameter("uid", uid)
+            .setParameter("fom", fom)
+            .setMaxResults(15)
+            .getResultList();
     }
 
     public List<Oppgave> hentSaksbehandlersReserverteAktiveOppgaver(String uid) {


### PR DESCRIPTION
Marte Lill og Benedicte fremmet et ønske om å begrense hvor gamle reservasjoner som vises i "Siste behandlinger"-panelet i los. Vi gikk for tre uker.

Dropper i tilegg bruk av upper() i query. Siste lowercaset verdi i databasen er fra 2020. Skal gi noe ytelsesforbedring om man legger til grunn explain plan i sqldeveloper.