### PR TITLE
Tilrettelegge for autotest - eksponer oppgavekriterier

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
@@ -61,7 +61,7 @@ public class Oppgave extends BaseEntitet {
     @Column(name = "BEHANDLING_TYPE")
     protected BehandlingType behandlingType = BehandlingType.INNSYN;
 
-    @OneToMany(mappedBy = "oppgave", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "oppgave")
     protected Set<OppgaveEgenskap> oppgaveEgenskaper;
 
     @Convert(converter = FagsakYtelseType.KodeverdiConverter.class)

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
@@ -10,7 +10,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -85,7 +84,7 @@ public class Oppgave extends BaseEntitet {
     @Embedded
     protected BehandlingId behandlingId;
 
-    @OneToOne(mappedBy = "oppgave", fetch = FetchType.LAZY)
+    @OneToOne(mappedBy = "oppgave")
     protected Reservasjon reservasjon;
 
     public Long getId() {

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
@@ -67,11 +67,8 @@ public class OppgaveRepository {
 
     public int hentAntallOppgaver(Oppgavespørring oppgavespørring) {
         var selection = COUNT_FRA_OPPGAVE;
-        if (oppgavespørring.getSortering() != null) {
-            selection = switch (oppgavespørring.getSortering().getFeltkategori()) {
-                case KøSortering.FK_TILBAKEKREVING -> COUNT_FRA_TILBAKEKREVING_OPPGAVE;
-                default -> COUNT_FRA_OPPGAVE;
-            };
+        if (KøSortering.FK_TILBAKEKREVING.equalsIgnoreCase(oppgavespørring.getSortering().getFeltkategori())) {
+            selection = COUNT_FRA_TILBAKEKREVING_OPPGAVE;
         }
         var oppgaveTypedQuery = lagOppgavespørring(selection, Long.class, oppgavespørring);
         return oppgaveTypedQuery.getSingleResult().intValue();
@@ -90,11 +87,8 @@ public class OppgaveRepository {
 
     public List<Oppgave> hentOppgaver(Oppgavespørring oppgavespørring, int maksAntall) {
         var selection = SELECT_FRA_OPPGAVE;
-        if (oppgavespørring.getSortering() != null) {
-            selection = switch (oppgavespørring.getSortering().getFeltkategori()) {
-                case KøSortering.FK_TILBAKEKREVING -> SELECT_FRA_TILBAKEKREVING_OPPGAVE;
-                default -> SELECT_FRA_OPPGAVE;
-            };
+        if (KøSortering.FK_TILBAKEKREVING.equalsIgnoreCase(oppgavespørring.getSortering().getFeltkategori())) {
+            selection = SELECT_FRA_TILBAKEKREVING_OPPGAVE;
         }
         var oppgaveTypedQuery = lagOppgavespørring(selection, Oppgave.class, oppgavespørring);
         if (maksAntall > 0) {
@@ -144,33 +138,32 @@ public class OppgaveRepository {
         if (!queryDto.getYtelseTyper().isEmpty()) {
             query.setParameter("fagsakYtelseType", queryDto.getYtelseTyper());
         }
-        if (queryDto.getSortering() != null) {
-            if (FT_HELTALL.equalsIgnoreCase(queryDto.getSortering().getFelttype())) {
-                if (queryDto.getFiltrerFra() != null) {
-                    query.setParameter("filterFra", BigDecimal.valueOf(queryDto.getFiltrerFra()));
-                }
-                if (queryDto.getFiltrerTil() != null) {
-                    query.setParameter("filterTil", BigDecimal.valueOf(queryDto.getFiltrerTil()));
-                }
-            } else if (FT_DATO.equalsIgnoreCase(queryDto.getSortering().getFelttype())) {
-                if (queryDto.getFiltrerFra() != null) {
-                    query.setParameter("filterFomDager", KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? LocalDate.now()
-                        .plusDays(queryDto.getFiltrerFra()) : LocalDateTime.now().plusDays(queryDto.getFiltrerFra()).with(LocalTime.MIN));
-                }
-                if (queryDto.getFiltrerTil() != null) {
-                    query.setParameter("filterTomDager", KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? LocalDate.now()
-                        .plusDays(queryDto.getFiltrerTil()) : LocalDateTime.now().plusDays(queryDto.getFiltrerTil()).with(LocalTime.MAX));
-                }
-                if (queryDto.getFiltrerFomDato() != null) {
-                    query.setParameter("filterFomDato",
-                        KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? queryDto.getFiltrerFomDato() : queryDto.getFiltrerFomDato()
-                            .atTime(LocalTime.MIN));
-                }
-                if (queryDto.getFiltrerTomDato() != null) {
-                    query.setParameter("filterTomDato",
-                        KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? queryDto.getFiltrerTomDato() : queryDto.getFiltrerTomDato()
-                            .atTime(LocalTime.MAX));
-                }
+
+        if (FT_HELTALL.equalsIgnoreCase(queryDto.getSortering().getFelttype())) {
+            if (queryDto.getFiltrerFra() != null) {
+                query.setParameter("filterFra", BigDecimal.valueOf(queryDto.getFiltrerFra()));
+            }
+            if (queryDto.getFiltrerTil() != null) {
+                query.setParameter("filterTil", BigDecimal.valueOf(queryDto.getFiltrerTil()));
+            }
+        } else if (FT_DATO.equalsIgnoreCase(queryDto.getSortering().getFelttype())) {
+            if (queryDto.getFiltrerFra() != null) {
+                query.setParameter("filterFomDager", KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? LocalDate.now()
+                    .plusDays(queryDto.getFiltrerFra()) : LocalDateTime.now().plusDays(queryDto.getFiltrerFra()).with(LocalTime.MIN));
+            }
+            if (queryDto.getFiltrerTil() != null) {
+                query.setParameter("filterTomDager", KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? LocalDate.now()
+                    .plusDays(queryDto.getFiltrerTil()) : LocalDateTime.now().plusDays(queryDto.getFiltrerTil()).with(LocalTime.MAX));
+            }
+            if (queryDto.getFiltrerFomDato() != null) {
+                query.setParameter("filterFomDato",
+                    KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? queryDto.getFiltrerFomDato() : queryDto.getFiltrerFomDato()
+                        .atTime(LocalTime.MIN));
+            }
+            if (queryDto.getFiltrerTomDato() != null) {
+                query.setParameter("filterTomDato",
+                    KøSortering.FØRSTE_STØNADSDAG.equals(queryDto.getSortering()) ? queryDto.getFiltrerTomDato() : queryDto.getFiltrerTomDato()
+                        .atTime(LocalTime.MAX));
             }
         }
 

--- a/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveFiltrering.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveFiltrering.java
@@ -43,7 +43,7 @@ public class OppgaveFiltrering extends BaseEntitet {
     @Column(name = "navn", updatable = false)
     private String navn;
 
-    @Column(name = "sortering", updatable = false)
+    @Column(name = "sortering", updatable = false, nullable = false)
     @Convert(converter = KøSortering.KodeverdiConverter.class)
     private KøSortering sortering;
 

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDto.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDto.java
@@ -1,14 +1,18 @@
 package no.nav.foreldrepenger.los.tjenester.felles.dto;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import no.nav.foreldrepenger.los.domene.typer.BehandlingId;
 import no.nav.foreldrepenger.los.domene.typer.aktør.Person;
+import no.nav.foreldrepenger.los.oppgave.AndreKriterierType;
 import no.nav.foreldrepenger.los.oppgave.BehandlingStatus;
 import no.nav.foreldrepenger.los.oppgave.BehandlingType;
 import no.nav.foreldrepenger.los.oppgave.FagsakYtelseType;
 import no.nav.foreldrepenger.los.oppgave.Oppgave;
+import no.nav.foreldrepenger.los.oppgave.OppgaveEgenskap;
 
 public class OppgaveDto {
     private Long id;
@@ -24,6 +28,7 @@ public class OppgaveDto {
     private LocalDateTime opprettetTidspunkt;
     private LocalDateTime behandlingsfrist;
     private BehandlingId behandlingId;
+    private Set<AndreKriterierType> andreKriterier;
 
     OppgaveDto(Oppgave oppgave, Person personDto, ReservasjonStatusDto oppgaveStatus) {
         leggTilOppgaveInformasjon(oppgave, oppgaveStatus);
@@ -42,6 +47,10 @@ public class OppgaveDto {
         this.erTilSaksbehandling = oppgave.getAktiv();
         this.opprettetTidspunkt = oppgave.getBehandlingOpprettet();
         this.behandlingsfrist = oppgave.getBehandlingsfrist();
+        this.andreKriterier = oppgave.getOppgaveEgenskaper().stream()
+            .filter(OppgaveEgenskap::getAktiv)
+            .map(OppgaveEgenskap::getAndreKriterierType)
+            .collect(Collectors.toSet());
     }
 
     private void leggTilPersonInformasjon(Person person) {
@@ -97,24 +106,28 @@ public class OppgaveDto {
         return behandlingStatus;
     }
 
-
     public Boolean getErTilSaksbehandling() {
         return erTilSaksbehandling;
     }
 
+    public Set<AndreKriterierType> getAndreKriterier() {
+        return andreKriterier;
+    }
+
     @Override
     public String toString() {
-        return "<id=" + id + //$NON-NLS-1$
-            ", status=" + status.isErReservert() + //$NON-NLS-1$
-            ", saksnummer=" + saksnummer + //$NON-NLS-1$
-            ", behandlingId=" + behandlingId + //$NON-NLS-1$
-            ", system=" + system + //$NON-NLS-1$
-            ", behandlingstype=" + behandlingstype + //$NON-NLS-1$
-            ", opprettetTidspunkt=" + opprettetTidspunkt + //$NON-NLS-1$
-            ", behandlingsfrist=" + behandlingsfrist + //$NON-NLS-1$
-            ", fagsakYtelseType=" + fagsakYtelseType + //$NON-NLS-1$
-            ", behandlingStatus=" + behandlingStatus + //$NON-NLS-1$
-            ", erTilSaksbehandling=" + erTilSaksbehandling + //$NON-NLS-1$
+        return "<id=" + id +
+            ", status=" + status.isErReservert() +
+            ", saksnummer=" + saksnummer +
+            ", behandlingId=" + behandlingId +
+            ", system=" + system +
+            ", behandlingstype=" + behandlingstype +
+            ", opprettetTidspunkt=" + opprettetTidspunkt +
+            ", behandlingsfrist=" + behandlingsfrist +
+            ", fagsakYtelseType=" + fagsakYtelseType +
+            ", behandlingStatus=" + behandlingStatus +
+            ", erTilSaksbehandling=" + erTilSaksbehandling +
+            ", andreKriterier=" + andreKriterier +
             ">";
     }
 
@@ -123,11 +136,9 @@ public class OppgaveDto {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof OppgaveDto)) {
+        if (!(o instanceof OppgaveDto oppgaveDto)) {
             return false;
         }
-
-        var oppgaveDto = (OppgaveDto) o;
         if (saksnummer.equals(oppgaveDto.saksnummer)) {
             return true;
         }

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
@@ -63,7 +63,7 @@ class OppgaveRepositoryTest {
     }
 
     private Oppgavespørring oppgaverForDrammenSpørring() {
-        return new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false,
+        return new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false,
             null, null, null, null);
     }
 
@@ -114,33 +114,33 @@ class OppgaveRepositoryTest {
     @Test
     void testEkskluderingOgInkluderingAvOppgaver() {
         lagStandardSettMedOppgaver();
-        var oppgaver = oppgaveRepository.hentOppgaver(new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(),
+        var oppgaver = oppgaveRepository.hentOppgaver(new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(),
             List.of(AndreKriterierType.TIL_BESLUTTER, AndreKriterierType.PAPIRSØKNAD), new ArrayList<>(), false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.TIL_BESLUTTER),
+            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.TIL_BESLUTTER),
                 new ArrayList<>(), false, null, null, null, null));
         assertThat(oppgaver).hasSize(2);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 List.of(AndreKriterierType.TIL_BESLUTTER, AndreKriterierType.PAPIRSØKNAD), // ekskluder andreKriterierType
                 false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 List.of(AndreKriterierType.TIL_BESLUTTER),  // ekskluderAndreKriterierType
                 false, null, null, null, null));
         assertThat(oppgaver).hasSize(2);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
+            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
                 List.of(AndreKriterierType.TIL_BESLUTTER), false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
         var antallOppgaver = oppgaveRepository.hentAntallOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), null, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
+            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
                 List.of(AndreKriterierType.TIL_BESLUTTER), false, null, null, null, null));
         assertThat(antallOppgaver).isEqualTo(1);
 


### PR DESCRIPTION
Jeg behøver å hente ut flere oppgavedetaljer for å kunne teste i VTP. Foreslår at vi eksponerer kriteriene gjennom den ordinære oppgavemappingen, og bruke endepunktet /saksbehandler/oppgaver/oppgaver-for-fagsaker for å hente oppgavene. Ikke planlagt å ta i bruk andrekriterier brukes i frontend for saksbehandlere. 

Ytelse: ved henting av oppgaver så mappes det opp 21 oppgaver, som nå utvides til å også joine inn OppgaveEgenskap eagerly.