### PR TITLE
Admin: fjern gruppemedlemskap når sbh slutter

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjeneste.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.los.avdelingsleder;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -51,6 +52,11 @@ public class AvdelingslederSaksbehandlerTjeneste {
             .orElseThrow(() -> AvdelingSaksbehandlerTjenesteFeil.finnerIkkeSaksbehandler(saksbehandlerIdent));
         saksbehandler.fjernAvdeling(organisasjonRepository.hentAvdelingFraEnhet(avdelingEnhet).orElseThrow());
         organisasjonRepository.persistFlush(saksbehandler);
+
+        var grupper =  organisasjonRepository.hentSaksbehandlerGrupper(avdelingEnhet);
+        grupper.stream()
+            .filter(g -> g.getSaksbehandlere().stream().anyMatch(s -> Objects.equals(saksbehandlerIdent, s.getSaksbehandlerIdent())))
+            .forEach(g -> organisasjonRepository.fjernSaksbehandlerFraGruppe(saksbehandlerIdent, g.getId(), avdelingEnhet));
 
         var avdeling = hentAvdeling(avdelingEnhet);
         var oppgaveFiltreringList = avdeling.getOppgaveFiltrering();

--- a/src/main/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/organisasjon/OrganisasjonRepository.java
@@ -78,6 +78,17 @@ public class OrganisasjonRepository {
         LOG.info("Slettet {} saksbehandlere uten knytninger til køer", slettedeRader);
     }
 
+    public void slettLøseGruppeKnytninger() {
+        int slettedeRader = entityManager.createNativeQuery("""
+                delete from gruppe_tilknytning gt
+                where not exists (select *
+                                  from avdeling_saksbehandler avd join SAKSBEHANDLER_GRUPPE sg on sg.avdeling_id = avd.avdeling_id
+                                  where avd.saksbehandler_id = gt.saksbehandler_id)
+                """)
+            .executeUpdate();
+        LOG.info("Slettet {} løse gruppe-knytninger", slettedeRader);
+    }
+
 
     public void slettØvrigeEnhetsdata(String avdelingEnhet) {
         var avdeling = hentAvdelingFraEnhet(avdelingEnhet).orElse(null);

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/AdminRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/AdminRestTjeneste.java
@@ -121,4 +121,15 @@ public class AdminRestTjeneste {
         return Response.ok().build();
     }
 
+    @POST
+    @Path("/slett-lose-gruppe-knytninger")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Fjerne saksbehandlere fra grupper når saksbehandler mangler i avdeling", tags = "admin")
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT, sporingslogg = false)
+    public Response slettLøseGruppeKnytninger() {
+        organisasjonRepository.slettLøseGruppeKnytninger();
+        return Response.ok().build();
+    }
+
 }


### PR DESCRIPTION
Fjerner også medlemskap i grupper for å slippe logg-spam som sist uke: Fjern saksbehandler, relasjon til avdeling, relasjon til gruppe og relasjon til kø.