### PR TITLE
TFP-5972 mer failsafe los og rasere initiell respons

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgave.java
@@ -33,7 +33,7 @@ public class Oppgave extends BaseEntitet {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_OPPGAVE")
     protected Long id;
 
-    @Column(name = "FAGSAK_SAKSNR")
+    @Column(name = "FAGSAK_SAKSNR", nullable = false)
     protected Long fagsakSaksnummer;
 
     @Embedded

--- a/src/main/java/no/nav/foreldrepenger/los/server/abac/PdpRequestBuilderImpl.java
+++ b/src/main/java/no/nav/foreldrepenger/los/server/abac/PdpRequestBuilderImpl.java
@@ -6,11 +6,9 @@ import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Alternative;
 import jakarta.inject.Inject;
-import no.nav.foreldrepenger.los.hendelse.hendelseoppretter.hendelse.Fagsystem;
 import no.nav.foreldrepenger.los.oppgave.Oppgave;
 import no.nav.foreldrepenger.los.oppgave.OppgaveTjeneste;
 import no.nav.foreldrepenger.los.tjenester.avdelingsleder.saksliste.FplosAbacAttributtType;
-import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.PdpRequestBuilder;
@@ -25,12 +23,10 @@ public class PdpRequestBuilderImpl implements PdpRequestBuilder {
 
     private static final MdcExtendedLogContext MDC_EXTENDED_LOG_CONTEXT = MdcExtendedLogContext.getContext("prosess");
 
-    private final ForeldrepengerPipKlient foreldrepengerPipKlient;
     private final OppgaveTjeneste oppgaveTjeneste;
 
     @Inject
-    public PdpRequestBuilderImpl(ForeldrepengerPipKlient foreldrepengerPipKlient, OppgaveTjeneste oppgaveTjeneste) {
-        this.foreldrepengerPipKlient = foreldrepengerPipKlient;
+    public PdpRequestBuilderImpl(OppgaveTjeneste oppgaveTjeneste) {
         this.oppgaveTjeneste = oppgaveTjeneste;
     }
 
@@ -43,20 +39,10 @@ public class PdpRequestBuilderImpl implements PdpRequestBuilder {
         }
 
         setLogContext(oppgave);
-
-        var ressursData = minimalbuilder()
-            .medAuditIdent(oppgave.getAktørId().getId());
-        var system = oppgave.getSystem();
-        if (Fagsystem.FPSAK.name().equals(system)) {
-            var dto = foreldrepengerPipKlient.hentPipdataForSak(oppgave.getSaksnummer());
-            ressursData.leggTilAktørIdSet(dto);
-        } else if (Fagsystem.FPTILBAKE.name().equals(system)) {
-            ressursData.leggTilAktørId(oppgave.getAktørId().getId());
-        } else {
-            throw new TekniskException("FPLOS-0003", String.format("Kunne ikke lage PDP-request: ukjent system %s", system));
-        }
-
-        return ressursData.build();
+        return minimalbuilder()
+            .medAuditIdent(oppgave.getAktørId().getId())
+            .medSaksnummer(oppgave.getSaksnummer())
+            .build();
     }
 
     @Override

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/reservasjon/ReservasjonRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/reservasjon/ReservasjonRestTjeneste.java
@@ -73,7 +73,7 @@ public class ReservasjonRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public ReservasjonStatusDto reserverOppgave(@NotNull @Parameter(description = "id til oppgaven") @Valid OppgaveIdDto oppgaveId) {
         var reservasjon = reservasjonTjeneste.reserverOppgave(oppgaveId.getVerdi());
-        return oppgaveDtoTjeneste.lagDtoFor(reservasjon.getOppgave()).getStatus();
+        return oppgaveDtoTjeneste.lagOppgaveStatusUtenPersonoppslag(reservasjon.getOppgave());
     }
 
     @GET
@@ -83,8 +83,7 @@ public class ReservasjonRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public ReservasjonStatusDto hentReservasjon(@NotNull @Parameter(description = "id til oppgaven") @QueryParam("oppgaveId") @Valid OppgaveIdDto oppgaveId) {
         var oppgave = oppgaveTjeneste.hentOppgave(oppgaveId.getVerdi());
-        var oppgaveDto = oppgaveDtoTjeneste.lagDtoFor(oppgave);
-        return oppgaveDto.getStatus();
+        return oppgaveDtoTjeneste.lagOppgaveStatusUtenPersonoppslag(oppgave);
     }
 
 
@@ -96,7 +95,7 @@ public class ReservasjonRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public ReservasjonStatusDto opphevReservasjonTilknyttetOppgave(@NotNull @Parameter(description = "Id og begrunnelse") @Valid OpphevTilknyttetReservasjonRequestDto request) {
         var reservasjon = reservasjonTjeneste.slettReservasjonMedEventLogg(request.getOppgaveId().getVerdi(), request.getBegrunnelse());
-        return reservasjon.map(Reservasjon::getOppgave).map(oppgaveDtoTjeneste::lagOppgaveStatusUtenTilgangsjekk).orElseGet(() -> {
+        return reservasjon.map(Reservasjon::getOppgave).map(oppgaveDtoTjeneste::lagOppgaveStatusUtenPersonoppslag).orElseGet(() -> {
             LOG.info("Fant ikke reservasjon tilknyttet oppgaveId {} for sletting, returnerer null", request.getOppgaveId());
             return null;
         });
@@ -110,7 +109,7 @@ public class ReservasjonRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public ReservasjonStatusDto forlengOppgaveReservasjon(@NotNull @Parameter(description = "id til oppgaven") @Valid OppgaveIdDto oppgaveId) {
         var reservasjon = reservasjonTjeneste.forlengReservasjonPåOppgave(oppgaveId.getVerdi());
-        return oppgaveDtoTjeneste.lagDtoFor(reservasjon.getOppgave()).getStatus();
+        return oppgaveDtoTjeneste.lagOppgaveStatusUtenPersonoppslag(reservasjon.getOppgave());
     }
 
     @POST
@@ -122,7 +121,7 @@ public class ReservasjonRestTjeneste {
     public ReservasjonStatusDto endreOppgaveReservasjon(@NotNull @Parameter(description = "forleng til dato") @Valid ReservasjonEndringRequestDto reservasjonsEndring) {
         var tidspunkt = ReservasjonTidspunktUtil.utledReservasjonTidspunkt(reservasjonsEndring.reserverTil());
         var reservasjon = reservasjonTjeneste.endreReservasjonPåOppgave(reservasjonsEndring.oppgaveId().getVerdi(), tidspunkt);
-        return oppgaveDtoTjeneste.lagDtoFor(reservasjon.getOppgave()).getStatus();
+        return oppgaveDtoTjeneste.lagOppgaveStatusUtenPersonoppslag(reservasjon.getOppgave());
     }
 
     @GET
@@ -156,7 +155,7 @@ public class ReservasjonRestTjeneste {
         var reservasjon = reservasjonTjeneste.flyttReservasjon(oppgaveFlyttingDto.getOppgaveId().getVerdi(),
             oppgaveFlyttingDto.getBrukerIdent().getVerdi(), oppgaveFlyttingDto.getBegrunnelse());
         LOG.info("Reservasjon flyttet: {}", oppgaveFlyttingDto);
-        return oppgaveDtoTjeneste.lagDtoFor(reservasjon.getOppgave()).getStatus();
+        return oppgaveDtoTjeneste.lagOppgaveStatusUtenPersonoppslag(reservasjon.getOppgave());
     }
 
     @GET


### PR DESCRIPTION
Rydde opp i Dto-metoden. Det er svært sjelden saker blir filtrert vekk, så sjekker bare om det finnes oppgaver.
Dessuten rydde i reservasjon så den ikke gir feil på gamle personer i Dev. 
Trenger ikke kalle PDL her - oppgavene blir filtrert annet sted.