### PR TITLE
bugfix: takle at saksbehandlere har sluttet

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjeneste.java
@@ -72,7 +72,7 @@ public class AvdelingslederSaksbehandlerTjeneste {
     }
 
     private Saksbehandler opprettSaksbehandler(String ident) {
-        var ansattProfil = ansattTjeneste.hentBrukerProfil(ident);
+        var ansattProfil = ansattTjeneste.hentBrukerProfil(ident).orElseThrow();
         var saksbehandler = new Saksbehandler(ident.trim().toUpperCase(), ansattProfil.uid());
         organisasjonRepository.persistFlush(saksbehandler);
         return organisasjonRepository.hentSaksbehandlerHvisEksisterer(ident)

--- a/src/main/java/no/nav/foreldrepenger/los/organisasjon/ansatt/AnsattInfoKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/los/organisasjon/ansatt/AnsattInfoKlient.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.los.organisasjon.ansatt;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.enterprise.context.Dependent;
@@ -16,13 +17,13 @@ public class AnsattInfoKlient extends AbstractAnsattInfoKlient {
         super();
     }
 
-    public BrukerProfil brukerProfil(String ident) {
+    public Optional<BrukerProfil> brukerProfil(String ident) {
         var profil = super.hentAnsattInfoForIdent(ident);
-        return profil != null ? new BrukerProfil(profil.ansattOid(), profil.ansattIdent(), profil.navn(), profil.ansattVedEnhetId()) : null;
+        return Optional.ofNullable(profil).map(p -> new BrukerProfil(p.ansattOid(), p.ansattIdent(), p.navn(), p.ansattVedEnhetId()));
     }
 
-    public BrukerProfil brukerProfil(UUID saksbehandler) {
+    public Optional<BrukerProfil> brukerProfil(UUID saksbehandler) {
         var profil = super.hentAnsattInfoForOid(saksbehandler);
-        return profil != null ? new BrukerProfil(profil.ansattOid(), profil.ansattIdent(), profil.navn(), profil.ansattVedEnhetId()) : null;
+        return Optional.ofNullable(profil).map(p -> new BrukerProfil(p.ansattOid(), p.ansattIdent(), p.navn(), p.ansattVedEnhetId()));
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/SaksbehandlerDtoTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/SaksbehandlerDtoTjeneste.java
@@ -72,7 +72,7 @@ public class SaksbehandlerDtoTjeneste {
         try {
             var identDto = new SaksbehandlerBrukerIdentDto(saksbehandlerIdent);
             return organisasjonRepository.hentSaksbehandlerHvisEksisterer(saksbehandlerIdent).flatMap(this::hentBrukerProfil)
-                .or(() -> Optional.ofNullable(ansattTjeneste.hentBrukerProfil(saksbehandlerIdent)))
+                .or(() -> ansattTjeneste.hentBrukerProfil(saksbehandlerIdent))
                 .map(bp -> new SaksbehandlerDto(identDto, bp.navn(), bp.ansattAvdeling()));
         } catch (IntegrasjonException e) {
             return Optional.empty();
@@ -81,7 +81,7 @@ public class SaksbehandlerDtoTjeneste {
     }
     public Optional<BrukerProfil> hentBrukerProfil(Saksbehandler saksbehandler) {
         try {
-            return Optional.of(ansattTjeneste.hentBrukerProfil(saksbehandler));
+            return ansattTjeneste.hentBrukerProfil(saksbehandler);
         } catch (IntegrasjonException e) {
             LOG.info("Henting av ansattnavn feilet, fortsetter med empty.", e);
             return Optional.empty();

--- a/src/test/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/avdelingsleder/AvdelingslederSaksbehandlerTjenesteTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -35,7 +36,7 @@ class AvdelingslederSaksbehandlerTjenesteTest {
     void setup(EntityManager entityManager) {
         var oppgaveRepository = new OppgaveRepository(entityManager);
         var organisasjonRepository = new OrganisasjonRepository(entityManager);
-        when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867"));
+        when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(Optional.of(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867")));
         avdelingslederSaksbehandlerTjeneste = new AvdelingslederSaksbehandlerTjeneste(oppgaveRepository, organisasjonRepository, ansattTjeneste);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTaskTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTaskTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -43,7 +44,7 @@ class SlettDeaktiverteAvdelingerTaskTest {
         var organisasjonRepository = new OrganisasjonRepository(entityManager);
         var oppgaveRepository = new OppgaveRepository(entityManager);
         var avdelingslederTjeneste = new AvdelingslederTjeneste(oppgaveRepository, organisasjonRepository);
-        lenient().when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867"));
+        lenient().when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(Optional.of(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867")));
         this.avdelingslederSaksbehandlerTjeneste = new AvdelingslederSaksbehandlerTjeneste(oppgaveRepository, organisasjonRepository, ansattTjeneste);
         task = new SlettDeaktiverteAvdelingerTask(oppgaveRepository, organisasjonRepository, avdelingslederTjeneste,
             avdelingslederSaksbehandlerTjeneste);

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/avdelingsleder/saksbehandler/AvdelingslederSaksbehandlerRestTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/avdelingsleder/saksbehandler/AvdelingslederSaksbehandlerRestTjenesteTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -57,7 +58,7 @@ class AvdelingslederSaksbehandlerRestTjenesteTest {
     @BeforeEach
     public void setUp(EntityManager entityManager) {
         var organisasjonRepository = new OrganisasjonRepository(entityManager);
-        lenient().when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867"));
+        lenient().when(ansattTjeneste.hentBrukerProfil(anyString())).thenReturn(Optional.of(new BrukerProfil(UUID.randomUUID(), "A000001", "Ansatt Navn", "4867")));
         avdelingslederSaksbehandlerTjeneste = new AvdelingslederSaksbehandlerTjeneste(oppgaveRepository, organisasjonRepository, ansattTjeneste);
         restTjeneste = new AvdelingslederSaksbehandlerRestTjeneste(avdelingslederSaksbehandlerTjeneste, saksbehandlerDtoTjeneste);
     }

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/SaksbehandlerDtoTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/SaksbehandlerDtoTjenesteTest.java
@@ -7,9 +7,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
-
-import no.nav.foreldrepenger.los.organisasjon.ansatt.BrukerProfil;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +24,7 @@ import no.nav.foreldrepenger.los.oppgavekø.OppgaveKøTjeneste;
 import no.nav.foreldrepenger.los.organisasjon.OrganisasjonRepository;
 import no.nav.foreldrepenger.los.organisasjon.Saksbehandler;
 import no.nav.foreldrepenger.los.organisasjon.ansatt.AnsattTjeneste;
+import no.nav.foreldrepenger.los.organisasjon.ansatt.BrukerProfil;
 
 @ExtendWith(JpaExtension.class)
 class SaksbehandlerDtoTjenesteTest {
@@ -68,8 +68,8 @@ class SaksbehandlerDtoTjenesteTest {
     void testHentSaksbehandlerSomIkkeFinnesILos(EntityManager entityManager) {
         var saksbehandler1Ident = "Z999999";
 
-        when(ansattTjeneste.hentBrukerProfil(saksbehandler1Ident)).thenReturn(
-            new BrukerProfil(UUID.randomUUID(), saksbehandler1Ident, "Navn Navnesen", "Avdelingsnavnet"));
+        when(ansattTjeneste.hentBrukerProfil(saksbehandler1Ident))
+            .thenReturn(Optional.of(new BrukerProfil(UUID.randomUUID(), saksbehandler1Ident, "Navn Navnesen", "Avdelingsnavnet")));
         var saksbehandlerDto = saksbehandlerDtoTjeneste.saksbehandlerDtoForNavIdent(saksbehandler1Ident);
 
         assertThat(saksbehandlerDto)


### PR DESCRIPTION
Nå kommer det en nullpointer i hentBrukerProfil der man prøver putte i cache.
gjelder saksbehandler som har sluttet såpass grundig at de ikke lenger finnes i AD