### PR TITLE
fix: unngå å hente alle oppgaver når formålet er sjekke for eksistens

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
@@ -82,19 +82,13 @@ public class OppgaveRepository {
     }
 
     public List<Oppgave> hentOppgaver(Oppgavespørring oppgavespørring) {
-        return hentOppgaver(oppgavespørring, 0);
-    }
-
-    public List<Oppgave> hentOppgaver(Oppgavespørring oppgavespørring, int maksAntall) {
         var selection = SELECT_FRA_OPPGAVE;
         if (KøSortering.FK_TILBAKEKREVING.equalsIgnoreCase(oppgavespørring.getSortering().getFeltkategori())) {
             selection = SELECT_FRA_TILBAKEKREVING_OPPGAVE;
         }
-        var oppgaveTypedQuery = lagOppgavespørring(selection, Oppgave.class, oppgavespørring);
-        if (maksAntall > 0) {
-            oppgaveTypedQuery.setMaxResults(maksAntall);
-        }
-        return oppgaveTypedQuery.getResultList();
+        var query = lagOppgavespørring(selection, Oppgave.class, oppgavespørring);
+        oppgavespørring.getMaxAntallOppgaver().ifPresent(max -> query.setMaxResults(max.intValue()));
+        return query.getResultList();
     }
 
     private static String andreKriterierSubquery(Oppgavespørring queryDto) {

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
@@ -23,8 +23,9 @@ public class Oppgavespørring {
     private final Long filtrerFra;
     private final Long filtrerTil;
     private boolean forAvdelingsleder;
-    private Long avgrenseTilOppgaveId;
     private boolean ignorerReserversjoner;
+    private Long avgrenseTilOppgaveId;
+    private Long maxAntallOppgaver;
 
     public Oppgavespørring(OppgaveFiltrering oppgaveFiltrering) {
         sortering = oppgaveFiltrering.getSortering();
@@ -76,9 +77,12 @@ public class Oppgavespørring {
         this.forAvdelingsleder = forAvdelingsleder;
     }
 
-    public Oppgavespørring setAvgrensTilOppgaveId(Long oppgaveId) {
+    public void setAvgrensTilOppgaveId(Long oppgaveId) {
         this.avgrenseTilOppgaveId = oppgaveId;
-        return this;
+    }
+
+    public void setMaksAntall(int maksAntall) {
+        this.maxAntallOppgaver = (long) maksAntall;
     }
 
     public boolean getForAvdelingsleder() {
@@ -131,6 +135,10 @@ public class Oppgavespørring {
 
     public Optional<Long> getAvgrenseTilOppgaveId() {
         return Optional.ofNullable(avgrenseTilOppgaveId);
+    }
+
+    public Optional<Long> getMaxAntallOppgaver() {
+        return Optional.ofNullable(maxAntallOppgaver);
     }
 
     private List<AndreKriterierType> ekskluderAndreKriterierTyperFra(OppgaveFiltrering oppgaveFiltrering) {

--- a/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveKøTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveKøTjeneste.java
@@ -65,15 +65,14 @@ public class OppgaveKøTjeneste {
         return oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getId());
     }
 
-    public List<Oppgave> hentOppgaver(Long sakslisteId) {
-        return hentOppgaver(sakslisteId, 0);
-    }
-
     public List<Oppgave> hentOppgaver(Long sakslisteId, int maksAntall) {
-        return oppgaveRepository.hentOppgaveFilterSett(sakslisteId)
-            .map(Oppgavespørring::new)
-            .map(os -> oppgaveRepository.hentOppgaver(os, maksAntall))
-            .orElse(Collections.emptyList());
+        var oppgaveFilter = oppgaveRepository.hentOppgaveFilterSett(sakslisteId);
+        if (oppgaveFilter.isEmpty()) {
+            return Collections.emptyList();
+        }
+        var oppgavespørring = new Oppgavespørring(oppgaveFilter.get());
+        oppgavespørring.setMaksAntall(maksAntall);
+        return oppgaveRepository.hentOppgaver(oppgavespørring);
     }
 
     private Optional<OppgaveFiltreringKnytning> finnOppgaveFiltreringKnytning(Oppgave oppgave, OppgaveFiltrering oppgaveFiltrering) {

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjeneste.java
@@ -68,10 +68,6 @@ public class OppgaveDtoTjeneste {
         return reservasjonStatusDtoTjeneste.lagStatusFor(oppgave);
     }
 
-    public boolean finnesTilgjengeligeOppgaver(SakslisteIdDto sakslisteId) {
-        return !oppgaveKøTjeneste.hentOppgaver(sakslisteId.getVerdi()).isEmpty();
-    }
-
     public List<OppgaveDto> getOppgaverTilBehandling(Long sakslisteId) {
         var nesteOppgaver = oppgaveKøTjeneste.hentOppgaver(sakslisteId, ANTALL_OPPGAVER_UTVALG);
         var oppgaveDtos = map(nesteOppgaver, ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER, nesteOppgaver.size() == ANTALL_OPPGAVER_UTVALG);
@@ -80,7 +76,7 @@ public class OppgaveDtoTjeneste {
             return oppgaveDtos;
         }
         LOG.info("{} behandlinger filtrert bort for saksliste {}", nesteOppgaver.size() - oppgaveDtos.size(), sakslisteId);
-        var alleOppgaver = oppgaveKøTjeneste.hentOppgaver(sakslisteId);
+        var alleOppgaver = oppgaveKøTjeneste.hentOppgaver(sakslisteId, 150);
         return map(alleOppgaver, ANTALL_OPPGAVER_SOM_VISES_TIL_SAKSBEHANDLER, false);
     }
 

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
@@ -373,7 +373,6 @@ class OppgaveRepositoryTest {
         assertThat(filtrering).isEmpty();
     }
 
-
     private Oppgave første() {
         return DBTestUtil.hentAlle(entityManager, Oppgave.class).get(0);
     }

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
@@ -90,7 +90,7 @@ class OppgaveTjenesteTest {
     void testEnFiltreringpåBehandlingstype() {
         var listeId = leggeInnEtSettMedOppgaver();
         avdelingslederTjeneste.endreFiltreringBehandlingType(listeId, BehandlingType.FØRSTEGANGSSØKNAD, true);
-        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId);
+        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId, 100);
         assertThat(oppgaver).hasSize(1);
     }
 
@@ -108,7 +108,7 @@ class OppgaveTjenesteTest {
             .build();
         oppgaveRepository.lagre(opprettet);
 
-        var oppgaves = oppgaveKøTjeneste.hentOppgaver(opprettet.getId());
+        var oppgaves = oppgaveKøTjeneste.hentOppgaver(opprettet.getId(), 100);
         assertThat(oppgaves).containsSequence(førsteOppgave, andreOppgave, tredjeOppgave, fjerdeOppgave);
     }
 
@@ -122,7 +122,7 @@ class OppgaveTjenesteTest {
         var frist = OppgaveFiltrering.builder().medNavn("FRIST").medSortering(KøSortering.BEHANDLINGSFRIST).medAvdeling(avdelingDrammen(entityManager)).build();
         oppgaveRepository.lagre(frist);
 
-        var oppgaves = oppgaveKøTjeneste.hentOppgaver(frist.getId());
+        var oppgaves = oppgaveKøTjeneste.hentOppgaver(frist.getId(), 100);
         assertThat(oppgaves).containsSequence(førsteOppgave, andreOppgave, tredjeOppgave, fjerdeOppgave);
     }
 
@@ -140,7 +140,7 @@ class OppgaveTjenesteTest {
             .build();
         oppgaveRepository.lagre(førsteStønadsdag);
 
-        var oppgaves = oppgaveKøTjeneste.hentOppgaver(førsteStønadsdag.getId());
+        var oppgaves = oppgaveKøTjeneste.hentOppgaver(førsteStønadsdag.getId(), 100);
         assertThat(oppgaves).containsSequence(førsteOppgave, andreOppgave, tredjeOppgave, fjerdeOppgave);
     }
 
@@ -159,13 +159,13 @@ class OppgaveTjenesteTest {
     @Test
     void testReservasjon() {
         var oppgaveFiltreringId = leggeInnEtSettMedOppgaver();
-        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId)).hasSize(3);
+        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100)).hasSize(3);
         assertThat(reservasjonTjeneste.hentSaksbehandlersReserverteAktiveOppgaver()).isEmpty();
         assertThat(reservasjonTjeneste.hentReservasjonerForAvdeling(AVDELING_DRAMMEN_ENHET)).isEmpty();
         assertThat(reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus()).isEmpty();
 
         reservasjonTjeneste.reserverOppgave(førstegangOppgave);
-        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId)).hasSize(2);
+        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100)).hasSize(2);
         assertThat(reservasjonTjeneste.hentSaksbehandlersReserverteAktiveOppgaver()).hasSize(1);
         assertThat(reservasjonTjeneste.hentReservasjonerForAvdeling(AVDELING_DRAMMEN_ENHET)).hasSize(1);
         assertThat(reservasjonTjeneste.hentReservasjonerForAvdeling(AVDELING_BERGEN_ENHET)).isEmpty();
@@ -184,7 +184,7 @@ class OppgaveTjenesteTest {
         assertThat(reservasjon.getReservertTil().until(LocalDateTime.now().plusDays(3), MINUTES)).isLessThan(2);
 
         reservasjonTjeneste.slettReservasjonMedEventLogg(førstegangOppgave.getReservasjon(), "begrunnelse");
-        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId)).hasSize(3);
+        assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100)).hasSize(3);
         assertThat(reservasjonTjeneste.hentSaksbehandlersReserverteAktiveOppgaver()).isEmpty();
         assertThat(reservasjonTjeneste.hentReservasjonerForAvdeling(AVDELING_DRAMMEN_ENHET)).isEmpty();
     }

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
@@ -63,7 +63,7 @@ class OppgaveKøTjenesteTest {
         var listeId = leggeInnEtSettMedOppgaver();
         avdelingslederTjeneste.endreFiltreringBehandlingType(listeId, BehandlingType.FØRSTEGANGSSØKNAD, true);
         avdelingslederTjeneste.endreFiltreringBehandlingType(listeId, BehandlingType.KLAGE, true);
-        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId);
+        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId, 100);
         assertThat(oppgaver).hasSize(2);
     }
 
@@ -72,14 +72,14 @@ class OppgaveKøTjenesteTest {
         var listeId = leggeInnEtSettMedAndreKriterierOppgaver();
         avdelingslederTjeneste.endreFiltreringAndreKriterierType(listeId, AndreKriterierType.TIL_BESLUTTER, true, true);
         avdelingslederTjeneste.endreFiltreringAndreKriterierType(listeId, AndreKriterierType.PAPIRSØKNAD, true, true);
-        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId);
+        var oppgaver = oppgaveKøTjeneste.hentOppgaver(listeId, 100);
         assertThat(oppgaver).hasSize(1);
     }
 
     @Test
     void testUtenFiltreringpåBehandlingstype() {
         var oppgaveFiltreringId = leggeInnEtSettMedOppgaver();
-        var oppgaver = oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId);
+        var oppgaver = oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100);
         assertThat(oppgaver).hasSize(3);
     }
 


### PR DESCRIPTION
Første kallet ved valg av ny kø henter alle oppgaver. Det virker unødvendig og går tregt, bytter til en count-variant av query. Legger tilsvarende på en begrensning for ny henting av oppgaver når saksbehandler mangler tilgang til den første bunken med oppgaver fra køen.

Rydder bort litt forvirrende håndtering av maks antall oppgaver hentet fra køen, flytter begrensning til Oppgavespørring-objektet.