### PR TITLE
TFP-6364: innføre kun aktive-toggle for siste-reserverte

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/reservasjon/ReservasjonTjeneste.java
@@ -146,8 +146,8 @@ public class ReservasjonTjeneste {
         return reservasjon;
     }
 
-    public List<OppgaveBehandlingStatusWrapper> hentSaksbehandlersSisteReserverteMedStatus() {
-        var sisteReserverteMetadata = reservasjonRepository.hentSisteReserverteMetadata(BrukerIdent.brukerIdent());
+    public List<OppgaveBehandlingStatusWrapper> hentSaksbehandlersSisteReserverteMedStatus(boolean kunAktive) {
+        var sisteReserverteMetadata = reservasjonRepository.hentSisteReserverteMetadata(BrukerIdent.brukerIdent(), kunAktive);
         var oppgaveIder = sisteReserverteMetadata.stream().map(SisteReserverteMetadata::oppgaveId).toList();
         var oppgaveListe = oppgaveRepository.hentOppgaverReadOnly(oppgaveIder);
         var oppgaveMap = oppgaveListe.stream().collect(Collectors.toMap(Oppgave::getId, Function.identity()));

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjeneste.java
@@ -85,8 +85,8 @@ public class OppgaveDtoTjeneste {
         return lagDtoMedTilgangskontroll(oppgaver);
     }
 
-    public List<OppgaveDtoMedStatus> getSaksbehandlersSisteReserverteOppgaver() {
-        var oppgaverMedStatus = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus();
+    public List<OppgaveDtoMedStatus> getSaksbehandlersSisteReserverteOppgaver(boolean kunAktive) {
+        var oppgaverMedStatus = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus(kunAktive);
         var oppgaver = oppgaverMedStatus.stream().map(OppgaveBehandlingStatusWrapper::oppgave).toList();
         return lagDtoMedTilgangskontroll(oppgaver).stream()
             .map(dto -> {

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/reservasjon/ReservasjonRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/reservasjon/ReservasjonRestTjeneste.java
@@ -165,8 +165,9 @@ public class ReservasjonRestTjeneste {
     @Produces("application/json")
     @Operation(description = "Behandlede", tags = "Saksbehandler")
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
-    public List<OppgaveDtoMedStatus> sisteReserverte() {
-        return oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver();
+    public List<OppgaveDtoMedStatus> sisteReserverte(@Parameter(description = "vise kun aktive") @QueryParam("kunAktive") @Valid Boolean kunAktive) {
+        boolean kunAktiveValue = kunAktive != null && kunAktive;
+        return oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver(kunAktiveValue);
     }
 
 

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
@@ -205,6 +205,9 @@ class OppgaveTjenesteTest {
         assertThat(sisteReserverte)
             .hasSize(1)
             .first().matches(sr -> sr.status() == OppgaveBehandlingStatus.FERDIG);
+
+        var sisteReserverteAktive = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus(true);
+        assertThat(sisteReserverteAktive).isEmpty();
     }
 
     @Test

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveTjenesteTest.java
@@ -162,7 +162,7 @@ class OppgaveTjenesteTest {
         assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100)).hasSize(3);
         assertThat(reservasjonTjeneste.hentSaksbehandlersReserverteAktiveOppgaver()).isEmpty();
         assertThat(reservasjonTjeneste.hentReservasjonerForAvdeling(AVDELING_DRAMMEN_ENHET)).isEmpty();
-        assertThat(reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus()).isEmpty();
+        assertThat(reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus(false)).isEmpty();
 
         reservasjonTjeneste.reserverOppgave(førstegangOppgave);
         assertThat(oppgaveKøTjeneste.hentOppgaver(oppgaveFiltreringId, 100)).hasSize(2);
@@ -195,13 +195,13 @@ class OppgaveTjenesteTest {
         oppgaveRepository.lagre(opprettOppgaveEventLogg(førstegangOppgave));
 
         reservasjonTjeneste.reserverOppgave(førstegangOppgave);
-        var sisteReserverteEtterReservasjon = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus();
+        var sisteReserverteEtterReservasjon = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus(false);
         assertThat(sisteReserverteEtterReservasjon)
             .hasSize(1)
             .first().matches(sr -> sr.status() == OppgaveBehandlingStatus.UNDER_ARBEID);
 
         oppgaveTjeneste.avsluttOppgaveMedEventLogg(førstegangOppgave, OppgaveEventType.LUKKET, "Avsluttet oppgave");
-        var sisteReserverte = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus();
+        var sisteReserverte = reservasjonTjeneste.hentSaksbehandlersSisteReserverteMedStatus(false);
         assertThat(sisteReserverte)
             .hasSize(1)
             .first().matches(sr -> sr.status() == OppgaveBehandlingStatus.FERDIG);

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjenesteTest.java
@@ -82,14 +82,14 @@ class OppgaveDtoTjenesteTest {
             AndreKriterierType.TIL_BESLUTTER, oppgave.getBehandlendeEnhet()));
         reservasjonTjeneste.reserverOppgave(oppgave);
 
-        var sisteReserverteEtterReservasjon = oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver();
+        var sisteReserverteEtterReservasjon = oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver(false);
         assertThat(sisteReserverteEtterReservasjon)
             .hasSize(1)
             .first().matches(dto -> dto.getOppgaveBehandlingStatus() == OppgaveBehandlingStatus.TIL_BESLUTTER);
 
         oppgaveTjeneste.avsluttOppgaveMedEventLogg(oppgave, OppgaveEventType.LUKKET, "Avsluttet oppgave");
 
-        var sisteReserverte = oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver();
+        var sisteReserverte = oppgaveDtoTjeneste.getSaksbehandlersSisteReserverteOppgaver(false);
         assertThat(sisteReserverte)
             .hasSize(1)
             .first().matches(dto -> dto.getOppgaveBehandlingStatus() == OppgaveBehandlingStatus.FERDIG);


### PR DESCRIPTION
Etter innføringen av status gjennom TFP-5847 har vi tatt en titt på bruk. Stine ser en del som behandler mange saker. Et filter på kun åpne-statuser kan være formålstjenlig for å toggle mellom hele historikken og kun de fortsatt aktive.

Legger på en toggle switch i frontend og et kriterie i backend.