### PR TITLE
chore: forbereder fjerning av aktiv-flagg på OppgaveEgenskap

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
+++ b/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.los.hendelse.hendelsehåndterer;
 
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,7 @@ public class OppgaveEgenskapHåndterer {
             .filter(akt -> !andreKriterier.contains(akt.getAndreKriterierType()) || !akt.getAktiv())
             .forEach(repository::slett);
 
-        var eksisterendeTyper = eksisterendeOppgaveEgenskaper.stream().map(OppgaveEgenskap::getAndreKriterierType).toList();
+        var eksisterendeTyper = eksisterendeOppgaveEgenskaper.stream().map(OppgaveEgenskap::getAndreKriterierType).collect(Collectors.toSet());
         for (var type : andreKriterier) {
             if (!eksisterendeTyper.contains(type)) {
                 var builder = OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(type);

--- a/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
+++ b/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
@@ -1,22 +1,16 @@
 package no.nav.foreldrepenger.los.hendelse.hendelsehåndterer;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
-
-import no.nav.foreldrepenger.los.oppgave.AndreKriterierType;
-import no.nav.foreldrepenger.los.oppgave.OppgaveEgenskap;
-import no.nav.foreldrepenger.los.oppgave.OppgaveRepository;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import no.nav.foreldrepenger.los.oppgave.Oppgave;
+import no.nav.foreldrepenger.los.oppgave.OppgaveEgenskap;
+import no.nav.foreldrepenger.los.oppgave.OppgaveRepository;
 
 @ApplicationScoped
 @Transactional
@@ -32,8 +26,7 @@ public class OppgaveEgenskapHåndterer {
     }
 
     @Inject
-    public OppgaveEgenskapHåndterer(OppgaveRepository oppgaveRepository,
-                                    Beskyttelsesbehov beskyttelsesbehov) {
+    public OppgaveEgenskapHåndterer(OppgaveRepository oppgaveRepository, Beskyttelsesbehov beskyttelsesbehov) {
         this.repository = oppgaveRepository;
         this.beskyttelsesbehov = beskyttelsesbehov;
     }
@@ -42,53 +35,23 @@ public class OppgaveEgenskapHåndterer {
         var andreKriterier = new ArrayList<>(aktuelleEgenskaper.getAndreKriterier());
         andreKriterier.addAll(beskyttelsesbehov.getBeskyttelsesKriterier(oppgave));
         LOG.info("Legger på oppgaveegenskaper {}", andreKriterier);
-        var eksisterendeOppgaveEgenskaper = hentEksisterendeEgenskaper(oppgave);
+        var eksisterendeOppgaveEgenskaper = repository.hentOppgaveEgenskaper(oppgave.getId());
 
-        // deaktiver uaktuelle eksisterende
-        eksisterendeOppgaveEgenskaper.stream().filter(akt -> !andreKriterier.contains(akt.getAndreKriterierType())).forEach(this::deaktiver);
-
-        // aktiver aktuelle eksisterende
+        // slett uaktuelle eksisterende
         eksisterendeOppgaveEgenskaper.stream()
-            .filter(akt -> andreKriterier.contains(akt.getAndreKriterierType()))
-            .forEach(oe -> aktiver(oe, aktuelleEgenskaper.getSaksbehandlerForTotrinn()));
+            .filter(akt -> !andreKriterier.contains(akt.getAndreKriterierType()) || !akt.getAktiv())
+            .forEach(repository::slett);
 
-        var eksisterendeTyper = typer(eksisterendeOppgaveEgenskaper);
-
-        // aktiver nye
-        andreKriterier.stream()
-            .filter(akt -> !eksisterendeTyper.contains(akt))
-            .forEach(k -> opprettOppgaveEgenskap(oppgave, k, aktuelleEgenskaper.getSaksbehandlerForTotrinn()));
-    }
-
-    private void opprettOppgaveEgenskap(Oppgave oppgave, AndreKriterierType kritere, String saksbehandler) {
-        if (kritere.equals(AndreKriterierType.TIL_BESLUTTER)) {
-            repository.lagre(new OppgaveEgenskap(oppgave, kritere, saksbehandler));
-        } else {
-            repository.lagre(new OppgaveEgenskap(oppgave, kritere));
+        var eksisterendeTyper = eksisterendeOppgaveEgenskaper.stream().map(OppgaveEgenskap::getAndreKriterierType).toList();
+        for (var type : andreKriterier) {
+            if (!eksisterendeTyper.contains(type)) {
+                var builder = OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(type);
+                if (type.erTilBeslutter()) {
+                    builder.medSisteSaksbehandlerForTotrinn(aktuelleEgenskaper.getSaksbehandlerForTotrinn());
+                }
+                repository.lagre(builder.build());
+            }
         }
-    }
-
-    private void deaktiver(OppgaveEgenskap oppgaveEgenskap) {
-        oppgaveEgenskap.deaktiverOppgaveEgenskap();
-        repository.lagre(oppgaveEgenskap);
-    }
-
-    private void aktiver(OppgaveEgenskap oppgaveEgenskap, String saksbehandler) {
-        if (oppgaveEgenskap.getAndreKriterierType().erTilBeslutter()) {
-            oppgaveEgenskap.aktiverOppgaveEgenskap();
-            oppgaveEgenskap.setSisteSaksbehandlerForTotrinn(saksbehandler);
-        } else {
-            oppgaveEgenskap.aktiverOppgaveEgenskap();
-        }
-        repository.lagre(oppgaveEgenskap);
-    }
-
-    List<OppgaveEgenskap> hentEksisterendeEgenskaper(Oppgave oppgave) {
-        return Optional.ofNullable(repository.hentOppgaveEgenskaper(oppgave.getId())).orElse(Collections.emptyList());
-    }
-
-    private static List<AndreKriterierType> typer(List<OppgaveEgenskap> eksisterendeOppgaveEgenskaper) {
-        return eksisterendeOppgaveEgenskaper.stream().map(OppgaveEgenskap::getAndreKriterierType).toList();
     }
 
 }

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveEgenskap.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveEgenskap.java
@@ -31,6 +31,7 @@ public class OppgaveEgenskap extends BaseEntitet {
     @Column(name = "ANDRE_KRITERIER_TYPE", nullable = false)
     private AndreKriterierType andreKriterierType;
 
+    // feltet brukes i query for å ekskludere egne oppgaver i beslutterkøer
     @Column(name = "SISTE_SAKSBEHANDLER_FOR_TOTR")
     private String sisteSaksbehandlerForTotrinn;
 
@@ -42,21 +43,6 @@ public class OppgaveEgenskap extends BaseEntitet {
         //CDI
     }
 
-    public OppgaveEgenskap(Oppgave oppgave, AndreKriterierType andreKriterierType) {
-        this.oppgave = oppgave;
-        this.andreKriterierType = andreKriterierType;
-    }
-
-    public OppgaveEgenskap(Oppgave oppgave, AndreKriterierType type, String sisteSaksbehandlerForTotrinn) {
-        this.oppgave = oppgave;
-        this.andreKriterierType = type;
-        this.sisteSaksbehandlerForTotrinn = sisteSaksbehandlerForTotrinn;
-    }
-
-    public OppgaveEgenskap beslutterEgenskapFra(Oppgave oppgave, String sisteSaksbehandlerForTotrinn) {
-        return new OppgaveEgenskap(oppgave, AndreKriterierType.TIL_BESLUTTER, sisteSaksbehandlerForTotrinn);
-    }
-
     public Oppgave getOppgave() {
         return oppgave;
     }
@@ -65,23 +51,51 @@ public class OppgaveEgenskap extends BaseEntitet {
         return andreKriterierType;
     }
 
-    public String getSisteSaksbehandlerForTotrinn() {
-        return sisteSaksbehandlerForTotrinn;
-    }
-
     public Boolean getAktiv() {
         return aktiv;
     }
 
-    public void deaktiverOppgaveEgenskap() {
-        aktiv = false;
+    public static Builder builder() {
+        return new Builder();
     }
 
-    public void aktiverOppgaveEgenskap() {
-        aktiv = true;
-    }
+    public static class Builder {
+        private Oppgave oppgave;
+        private AndreKriterierType andreKriterierType;
+        private String sisteSaksbehandlerForTotrinn;
 
-    public void setSisteSaksbehandlerForTotrinn(String sisteSaksbehandlerForTotrinn) {
-        this.sisteSaksbehandlerForTotrinn = sisteSaksbehandlerForTotrinn;
+        public Builder medOppgave(Oppgave oppgave) {
+            this.oppgave = oppgave;
+            return this;
+        }
+
+        public Builder medAndreKriterierType(AndreKriterierType andreKriterierType) {
+            this.andreKriterierType = andreKriterierType;
+            return this;
+        }
+
+        public Builder medSisteSaksbehandlerForTotrinn(String sisteSaksbehandler) {
+            if (sisteSaksbehandler == null || sisteSaksbehandler.isBlank()) {
+                throw new IllegalArgumentException("sisteSaksbehandlerForTotrinn kan ikke være null eller blank");
+            }
+            this.sisteSaksbehandlerForTotrinn = sisteSaksbehandler.toUpperCase();
+            return this;
+        }
+
+        public OppgaveEgenskap build() {
+            if (oppgave == null || andreKriterierType == null) {
+                throw new IllegalStateException("Oppgave og/eller AndreKriterierType kan ikke være null");
+            }
+
+            if (andreKriterierType.erTilBeslutter() && sisteSaksbehandlerForTotrinn == null) {
+                throw new IllegalStateException("Mangler sisteSaksbehandlerForTotrinn for AndreKriterierType " + AndreKriterierType.TIL_BESLUTTER);
+            }
+
+            var oppgaveEgenskap = new OppgaveEgenskap();
+            oppgaveEgenskap.oppgave = oppgave;
+            oppgaveEgenskap.andreKriterierType = andreKriterierType;
+            oppgaveEgenskap.sisteSaksbehandlerForTotrinn = sisteSaksbehandlerForTotrinn;
+            return oppgaveEgenskap;
+        }
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
@@ -288,6 +288,11 @@ public class OppgaveRepository {
         refresh(oppgaveEgenskap.getOppgave());
     }
 
+    public <U extends BaseEntitet> void slett(U entitet) {
+        entityManager.remove(entitet);
+        entityManager.flush();
+    }
+
     public void oppdaterNavn(Long sakslisteId, String navn) {
         entityManager.persist(entityManager.find(OppgaveFiltreringOppdaterer.class, sakslisteId).endreNavn(navn));
         entityManager.flush();

--- a/src/test/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndtererTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndtererTest.java
@@ -56,7 +56,6 @@ class OppgaveEgenskapHåndtererTest {
     void opprettOppgaveEgenskaperTest() {
         // arrange
         var ønskedeEgenskaper = kriterieArrayOf(UTLANDSSAK, PAPIRSØKNAD);
-        when(oppgaveEgenskapFinner.getSaksbehandlerForTotrinn()).thenReturn("T12345");
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(Arrays.asList(ønskedeEgenskaper));
 
         // act
@@ -70,7 +69,6 @@ class OppgaveEgenskapHåndtererTest {
     void opprettOppgaveEgenskaperMedKode7Test() {
         // arrange
         var ønskedeEgenskaper = kriterieArrayOf(UTLANDSSAK, PAPIRSØKNAD);
-        when(oppgaveEgenskapFinner.getSaksbehandlerForTotrinn()).thenReturn("T12345");
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(Arrays.asList(ønskedeEgenskaper));
         when(beskyttelsesbehov.getBeskyttelsesKriterier(any())).thenReturn(Set.of(AndreKriterierType.KODE7_SAK));
 
@@ -84,7 +82,7 @@ class OppgaveEgenskapHåndtererTest {
     @Test
     void deaktiverUaktuelleEksisterendeOppgaveEgenskaper() {
         var oppgave = lagOppgave();
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, PAPIRSØKNAD));
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(PAPIRSØKNAD).build());
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(emptyList());
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 
@@ -94,7 +92,7 @@ class OppgaveEgenskapHåndtererTest {
     @Test
     void kunEttAktivtTilfelleAvHverEgenskap() {
         var oppgave = lagOppgave();
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, UTLANDSSAK));
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(UTLANDSSAK).build());
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(List.of(UTLANDSSAK));
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 
@@ -105,10 +103,10 @@ class OppgaveEgenskapHåndtererTest {
     void deaktiveringHåndtererDuplikateOppgaveEgenskaper() {
         // Bug i prod har opprettet dubletter. Tester deaktivering av samtlige dubletter.
         var oppgave = lagOppgave();
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, PAPIRSØKNAD));
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, PAPIRSØKNAD));
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, PAPIRSØKNAD));
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, UTLANDSSAK));
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(PAPIRSØKNAD).build());
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(PAPIRSØKNAD).build());
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(PAPIRSØKNAD).build());
+        oppgaveRepository.lagre(OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(PAPIRSØKNAD).build());
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(emptyList());
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
@@ -86,7 +86,11 @@ class OppgaveRepositoryTest {
         var oppgave = Oppgave.builder().dummyOppgave(AVDELING_DRAMMEN_ENHET).medSaksnummer(saksnummer).build();
         entityManager.persist(oppgave);
         for (var kriterie : kriterier) {
-            entityManager.persist(new OppgaveEgenskap(oppgave, kriterie));
+            var oppgaveEgenskapBuilder = OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(kriterie);
+            if (kriterie.erTilBeslutter()) {
+                oppgaveEgenskapBuilder.medSisteSaksbehandlerForTotrinn("IDENT");
+            }
+            entityManager.persist(oppgaveEgenskapBuilder.build());
         }
         entityManager.flush();
         return saksnummer;
@@ -222,10 +226,18 @@ class OppgaveRepositoryTest {
         entityManager.persist(andreOppgave);
         entityManager.persist(tredjeOppgave);
         entityManager.persist(fjerdeOppgave);
-        entityManager.persist(new OppgaveEgenskap(førsteOppgave, AndreKriterierType.PAPIRSØKNAD));
-        entityManager.persist(new OppgaveEgenskap(andreOppgave, AndreKriterierType.TIL_BESLUTTER, "Jodajoda"));
-        entityManager.persist(new OppgaveEgenskap(tredjeOppgave, AndreKriterierType.PAPIRSØKNAD));
-        entityManager.persist(new OppgaveEgenskap(tredjeOppgave, AndreKriterierType.TIL_BESLUTTER));
+        entityManager.persist(OppgaveEgenskap.builder().medOppgave(førsteOppgave).medAndreKriterierType(AndreKriterierType.PAPIRSØKNAD).build());
+        entityManager.persist(OppgaveEgenskap.builder()
+            .medOppgave(andreOppgave)
+            .medAndreKriterierType(AndreKriterierType.TIL_BESLUTTER)
+            .medSisteSaksbehandlerForTotrinn("IDENT")
+            .build());
+        entityManager.persist(OppgaveEgenskap.builder().medOppgave(tredjeOppgave).medAndreKriterierType(AndreKriterierType.PAPIRSØKNAD).build());
+        entityManager.persist(OppgaveEgenskap.builder()
+            .medOppgave(førsteOppgave)
+            .medAndreKriterierType(AndreKriterierType.TIL_BESLUTTER)
+            .medSisteSaksbehandlerForTotrinn("IDENT")
+            .build());
         entityManager.persist(
             new OppgaveEventLogg(behandlingId1, OppgaveEventType.OPPRETTET, AndreKriterierType.PAPIRSØKNAD, AVDELING_DRAMMEN_ENHET));
         entityManager.persist(

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/kø/OppgaveKøTjenesteTest.java
@@ -134,7 +134,11 @@ class OppgaveKøTjenesteTest {
     private void leggtilOppgaveMedEkstraEgenskaper(Oppgave oppgave, AndreKriterierType andreKriterierType) {
         oppgaveRepository.lagre(oppgave);
         oppgaveRepository.refresh(oppgave);
-        oppgaveRepository.lagre(new OppgaveEgenskap(oppgave, andreKriterierType));
+        var oppgaveEgenskapBuilder = OppgaveEgenskap.builder().medOppgave(oppgave).medAndreKriterierType(andreKriterierType);
+        if (andreKriterierType.erTilBeslutter()) {
+            oppgaveEgenskapBuilder.medSisteSaksbehandlerForTotrinn("IDENT");
+        }
+        oppgaveRepository.lagre(oppgaveEgenskapBuilder.build());
     }
 
     private List<OppgaveFiltrering> leggInnEtSettMedLister(int antallLister) {

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDtoTjenesteTest.java
@@ -75,7 +75,11 @@ class OppgaveDtoTjenesteTest {
             .dummyOppgave(AVDELING_DRAMMEN_ENHET)
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
             .build();
-        var oppgaveEgenskaper = new OppgaveEgenskap(oppgave, AndreKriterierType.TIL_BESLUTTER, "IDENT");
+        var oppgaveEgenskaper = OppgaveEgenskap.builder()
+            .medOppgave(oppgave)
+            .medAndreKriterierType(AndreKriterierType.TIL_BESLUTTER)
+            .medSisteSaksbehandlerForTotrinn("IDENT")
+            .build();
         oppgaveRepository.lagre(oppgave);
         oppgaveRepository.lagre(oppgaveEgenskaper);
         oppgaveRepository.lagre(new OppgaveEventLogg(oppgave.getBehandlingId(), OppgaveEventType.OPPRETTET,

--- a/src/test/java/no/nav/foreldrepenger/los/tjenester/statistikk/OppgaveBeholdningStatistikkTjenesteTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/tjenester/statistikk/OppgaveBeholdningStatistikkTjenesteTest.java
@@ -68,10 +68,20 @@ class OppgaveBeholdningStatistikkTjenesteTest {
         entityManager.persist(innsynOppgave);
 
         entityManager.persist(beslutterOppgave);
-        entityManager.persist(new OppgaveEgenskap(beslutterOppgave, AndreKriterierType.TIL_BESLUTTER));
+        var oppgaveEgenskapBeslutterOppgave1 = OppgaveEgenskap.builder()
+            .medOppgave(beslutterOppgave)
+            .medAndreKriterierType(AndreKriterierType.TIL_BESLUTTER)
+            .medSisteSaksbehandlerForTotrinn("IDENT")
+            .build();
+        entityManager.persist(oppgaveEgenskapBeslutterOppgave1);
 
         entityManager.persist(beslutterOppgave2);
-        entityManager.persist(new OppgaveEgenskap(beslutterOppgave2, AndreKriterierType.TIL_BESLUTTER));
+        var oppgaveEgenskapBeslutterOppgave2 = OppgaveEgenskap.builder()
+            .medOppgave(beslutterOppgave2)
+            .medAndreKriterierType(AndreKriterierType.TIL_BESLUTTER)
+            .medSisteSaksbehandlerForTotrinn("IDENT")
+            .build();
+        entityManager.persist(oppgaveEgenskapBeslutterOppgave2);
 
         entityManager.persist(lukketOppgave);
 


### PR DESCRIPTION
I prinsippet skal vi bare ha aktive OppgaveEgenskaper tilknyttet oppgaver. For å unngå å ha med dette i ny composite index for ytelse ønsker jeg fjerne aktiv-flagget. Rydding starter med å stoppe videreføring av disse inaktive egenskapene for tilbakebetalingsoppgaver. Neste er å slette inaktive i db og legge på ny index.

Entiteter i los med collections med @ManyToOne-relasjon har ikke cascade persist/merge, så endringer må håndteres manuelt. Samtidig er det mye manuell flushing og refresh rundt omkring. Vi kan snakke om det er verdt å bytte ut til løsning mer i tråd med pattern i fpsak. I denne PR bare beholdt jeg dagens mønster i los.