### PR TITLE
Sletter inaktive oppgaveegenskaper

### DIFF
--- a/src/main/resources/db/migration/defaultDS/2.2/V2.2_12__fjern_inaktive_oppgaveegenskaper.sql
+++ b/src/main/resources/db/migration/defaultDS/2.2/V2.2_12__fjern_inaktive_oppgaveegenskaper.sql
@@ -1,0 +1,2 @@
+delete from OPPGAVE_EGENSKAP
+where aktiv = 'N';


### PR DESCRIPTION
Sletter omtrent 43 700 inaktive oppgaveegenskaper. 
Skal senere fjerne aktiv-flagg fra query, sette kolonne inaktiv og legge på indekser.