### PR TITLE
chore: OppgaveEgenskap aktiv-flagg saneres - fjerner bruk i oppgave query

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
+++ b/src/main/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndterer.java
@@ -40,7 +40,7 @@ public class OppgaveEgenskapHåndterer {
 
         // slett uaktuelle eksisterende
         eksisterendeOppgaveEgenskaper.stream()
-            .filter(akt -> !andreKriterier.contains(akt.getAndreKriterierType()) || !akt.getAktiv())
+            .filter(akt -> !andreKriterier.contains(akt.getAndreKriterierType()))
             .forEach(repository::slett);
 
         var eksisterendeTyper = eksisterendeOppgaveEgenskaper.stream().map(OppgaveEgenskap::getAndreKriterierType).collect(Collectors.toSet());

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveEgenskap.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveEgenskap.java
@@ -11,7 +11,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 
 import no.nav.foreldrepenger.los.felles.BaseEntitet;
-import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 
 @Entity(name = "OppgaveEgenskap")
 @Table(name = "OPPGAVE_EGENSKAP")
@@ -35,10 +34,6 @@ public class OppgaveEgenskap extends BaseEntitet {
     @Column(name = "SISTE_SAKSBEHANDLER_FOR_TOTR")
     private String sisteSaksbehandlerForTotrinn;
 
-    @Convert(converter = BooleanToStringConverter.class)
-    @Column(name = "AKTIV")
-    private Boolean aktiv = Boolean.TRUE;
-
     public OppgaveEgenskap() {
         //CDI
     }
@@ -49,10 +44,6 @@ public class OppgaveEgenskap extends BaseEntitet {
 
     public AndreKriterierType getAndreKriterierType() {
         return andreKriterierType;
-    }
-
-    public Boolean getAktiv() {
-        return aktiv;
     }
 
     public static Builder builder() {

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
@@ -177,7 +177,6 @@ public class OppgaveRepository {
             AND NOT EXISTS (
                 select oetilbesl.oppgave from OppgaveEgenskap oetilbesl
                 where oetilbesl.oppgave = o
-                    AND oetilbesl.aktiv = true
                     AND oetilbesl.andreKriterierType = :tilbeslutter
                     AND upper(oetilbesl.sisteSaksbehandlerForTotrinn) = upper(:uid)
             )""";

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDto.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/felles/dto/OppgaveDto.java
@@ -60,7 +60,6 @@ public class OppgaveDto {
         this.opprettetTidspunkt = oppgave.getBehandlingOpprettet();
         this.behandlingsfrist = oppgave.getBehandlingsfrist();
         this.andreKriterier = oppgave.getOppgaveEgenskaper().stream()
-            .filter(OppgaveEgenskap::getAktiv)
             .map(OppgaveEgenskap::getAndreKriterierType)
             .collect(Collectors.toSet());
         this.reservasjonStatus = reservasjonStatus;

--- a/src/test/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndtererTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/hendelse/hendelsehåndterer/OppgaveEgenskapHåndtererTest.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,7 +61,7 @@ class OppgaveEgenskapHåndtererTest {
         egenskapHandler.håndterOppgaveEgenskaper(lagOppgave(), oppgaveEgenskapFinner);
 
         // assert
-        Assertions.assertThat(hentAktiveKriterierPåOppgave(new Saksnummer("42"))).containsExactlyInAnyOrder(ønskedeEgenskaper);
+        Assertions.assertThat(hentAndreKriterierTypeListe(new Saksnummer("42"))).containsExactlyInAnyOrder(ønskedeEgenskaper);
     }
 
     @Test
@@ -76,7 +75,7 @@ class OppgaveEgenskapHåndtererTest {
         egenskapHandler.håndterOppgaveEgenskaper(lagOppgave(), oppgaveEgenskapFinner);
 
         // assert
-        Assertions.assertThat(hentAktiveKriterierPåOppgave(new Saksnummer("42"))).contains(AndreKriterierType.KODE7_SAK);
+        Assertions.assertThat(hentAndreKriterierTypeListe(new Saksnummer("42"))).contains(AndreKriterierType.KODE7_SAK);
     }
 
     @Test
@@ -86,7 +85,7 @@ class OppgaveEgenskapHåndtererTest {
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(emptyList());
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 
-        Assertions.assertThat(hentAktiveKriterierPåOppgave(new Saksnummer("42"))).isEmpty();
+        Assertions.assertThat(hentAndreKriterierTypeListe(new Saksnummer("42"))).isEmpty();
     }
 
     @Test
@@ -96,7 +95,7 @@ class OppgaveEgenskapHåndtererTest {
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(List.of(UTLANDSSAK));
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 
-        Assertions.assertThat(hentAktiveKriterierPåOppgave(new Saksnummer("42"))).containsExactly(UTLANDSSAK);
+        Assertions.assertThat(hentAndreKriterierTypeListe(new Saksnummer("42"))).containsExactly(UTLANDSSAK);
     }
 
     @Test
@@ -110,19 +109,18 @@ class OppgaveEgenskapHåndtererTest {
         when(oppgaveEgenskapFinner.getAndreKriterier()).thenReturn(emptyList());
         egenskapHandler.håndterOppgaveEgenskaper(oppgave, oppgaveEgenskapFinner);
 
-        Assertions.assertThat(hentAktiveKriterierPåOppgave(new Saksnummer("42"))).isEmpty();
+        Assertions.assertThat(hentAndreKriterierTypeListe(new Saksnummer("42"))).isEmpty();
     }
 
     private static AndreKriterierType[] kriterieArrayOf(AndreKriterierType... kriterier) {
         return kriterier; // ble hakket penere enn å ha AndreKriterierType[] overalt.
     }
 
-    private List<AndreKriterierType> hentAktiveKriterierPåOppgave(Saksnummer saksnummer) {
+    private List<AndreKriterierType> hentAndreKriterierTypeListe(Saksnummer saksnummer) {
         return oppgaveRepository.hentOppgaveEgenskaper(oppgaveId(saksnummer))
             .stream()
-            .filter(OppgaveEgenskap::getAktiv)
             .map(OppgaveEgenskap::getAndreKriterierType)
-            .collect(Collectors.toList());
+            .toList();
     }
 
     private Long oppgaveId(Saksnummer saksnummer) {


### PR DESCRIPTION
Det er kun aktive OppgaveEgenskaper i prod pt:

- #2216 er i prod
- Berørte eksisterende tilfeller i prod er patchet via IKT-667034.