### PR TITLE
chore: refaktorerer lagOppgavespørring-metoden

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveQueryMapper.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveQueryMapper.java
@@ -1,0 +1,236 @@
+package no.nav.foreldrepenger.los.oppgave;
+
+import static no.nav.foreldrepenger.los.oppgave.OppgaveRepository.COUNT_FRA_OPPGAVE;
+import static no.nav.foreldrepenger.los.oppgave.OppgaveRepository.COUNT_FRA_TILBAKEKREVING_OPPGAVE;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.Objects;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import no.nav.foreldrepenger.los.felles.util.BrukerIdent;
+import no.nav.foreldrepenger.los.oppgavekø.KøSortering;
+
+public class OppgaveQueryMapper {
+    private static final String ORDER_BY_SQL = "ORDER BY ";
+    private static final String DESC_SQL = " DESC";
+    private static final String BEHANDLINGSFRIST_FELT_SQL = "o.behandlingsfrist";
+    private static final String BEHANDLINGOPPRETTET_FELT_SQL = "o.behandlingOpprettet";
+    private static final String FØRSTE_STØNADSDAG_FELT_SQL = "o.førsteStønadsdag";
+    private static final String BELØP_FELT_SQL = "o.belop";
+    private static final String FEILUTBETALINGSTART_FELT_SQL = "o.feilutbetalingstart";
+
+    private OppgaveQueryMapper() { }
+
+    public static <T> TypedQuery<T> lagOppgavespørring(EntityManager entityManager, String selection, Class<T> resultClass, Oppgavespørring queryDto) {
+        var parameters = new HashMap<String, Object>();
+        parameters.put("enhetsnummer", queryDto.getEnhetsnummer());
+
+        var sb = new StringBuilder();
+        sb.append(selection);
+        sb.append(" WHERE o.behandlendeEnhet = :enhetsnummer ");
+        sb.append(filtrerBehandlingType(queryDto, parameters));
+        sb.append(filtrerYtelseType(queryDto, parameters));
+        sb.append(andreKriterierSubquery(queryDto, parameters));
+        sb.append(reserverteSubquery(parameters));
+        sb.append(tilBeslutter(queryDto, parameters));
+        sb.append(" AND o.aktiv = true ");
+        sb.append(sortering(selection, queryDto, parameters)); // TODO: skille order by og filter, hvis ikke blir det feil i antall query!
+
+        var query = entityManager.createQuery(sb.toString(), resultClass);
+        parameters.forEach(query::setParameter);
+
+        return query;
+    }
+
+    private static String andreKriterierSubquery(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
+        var inkluderAkt = queryDto.getInkluderAndreKriterierTyper();
+        var ekskluderAkt = queryDto.getEkskluderAndreKriterierTyper();
+
+        var sb = new StringBuilder();
+        if (!inkluderAkt.isEmpty()) {
+            parameters.put("inkluderAktKoder", inkluderAkt);
+            parameters.put("inkluderAktAntall", inkluderAkt.size());
+            sb.append(" AND :inkluderAktAntall = (")
+                .append("   SELECT COUNT(oe.andreKriterierType) ")
+                .append("   FROM OppgaveEgenskap oe ")
+                .append("   WHERE oe.oppgave = o ")
+                .append("     AND oe.andreKriterierType IN (:inkluderAktKoder)")
+                .append(" ) ");
+        }
+        if (!ekskluderAkt.isEmpty()) {
+            parameters.put("ekskluderAktKoder", ekskluderAkt);
+            sb.append("AND NOT EXISTS ( ")
+                .append("SELECT 1 FROM OppgaveEgenskap oe ")
+                .append("WHERE oe.oppgave = o AND oe.andreKriterierType IN (:ekskluderAktKoder)")
+                .append(") ");
+        }
+
+        return sb.toString();
+    }
+
+    private static String filtrerBehandlingType(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
+        if (queryDto.getBehandlingTyper().isEmpty()) {
+            return "";
+        }
+        parameters.put("behtyper", queryDto.getBehandlingTyper());
+        return "AND o.behandlingType in :behtyper ";
+    }
+
+    private static String filtrerYtelseType(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
+        if (queryDto.getYtelseTyper().isEmpty()) {
+            return "";
+        }
+        parameters.put("fagsakYtelseType", queryDto.getYtelseTyper());
+        return "AND o.fagsakYtelseType in :fagsakYtelseType ";
+    }
+
+    private static String reserverteSubquery(HashMap<String, Object> parameters) {
+        parameters.put("nå", LocalDateTime.now());
+        return "AND NOT EXISTS (select r from Reservasjon r where r.oppgave = o and r.reservertTil > :nå) ";
+    }
+
+    private static String tilBeslutter(Oppgavespørring dto, HashMap<String, Object> parameters) {
+        var tilBeslutterKø = dto.getInkluderAndreKriterierTyper().contains(AndreKriterierType.TIL_BESLUTTER);
+        if (dto.getForAvdelingsleder() || !tilBeslutterKø) {
+            return "";
+        }
+        parameters.put("tilbeslutter", AndreKriterierType.TIL_BESLUTTER);
+        parameters.put("uid", BrukerIdent.brukerIdent());
+        return """
+            AND NOT EXISTS (
+                select oetilbesl.oppgave from OppgaveEgenskap oetilbesl
+                where oetilbesl.oppgave = o
+                    AND oetilbesl.andreKriterierType = :tilbeslutter
+                    AND upper(oetilbesl.sisteSaksbehandlerForTotrinn) = :uid
+            )""";
+    }
+
+    private static String sortering(String selection, Oppgavespørring oppgavespørring, HashMap<String, Object> parameters) {
+        if (selection.equals(COUNT_FRA_OPPGAVE) || selection.equals(COUNT_FRA_TILBAKEKREVING_OPPGAVE)) {
+            return "";
+        }
+        var sortering = oppgavespørring.getSortering();
+
+        // Oppsettet for sortering av køen inneholder også et de facto filter.
+        // Filteret kan enten være feilutbetalt beløp eller dato (x antall dager relativt til dd eller absolutte datoer)
+        // Spesielt for dynamisk filter: x kan også være negativ for å filtrere tilbake i tid.
+        if (KøSortering.FT_HELTALL.equalsIgnoreCase(oppgavespørring.getSortering().getFelttype())) {
+            // her er vi i beløpsvarianten
+            if (oppgavespørring.getFiltrerFra() != null) {
+                parameters.put("filterFra", BigDecimal.valueOf(oppgavespørring.getFiltrerFra()));
+            }
+            if (oppgavespørring.getFiltrerTil() != null) {
+                parameters.put("filterTil", BigDecimal.valueOf(oppgavespørring.getFiltrerTil()));
+            }
+        } else if (KøSortering.FT_DATO.equalsIgnoreCase(oppgavespørring.getSortering().getFelttype())) {
+            // her er vi i dato-varianten, først ut dynamisk variant relativt til i dag
+            if (oppgavespørring.getFiltrerFra() != null) {
+                // Hvorfor sjekk mot KøSortering.FØRSTE_STØNADSDAG? Første_stønadsdag er LocalDate, øvrige LocalDateTime.
+                // TODO: Vurdere å migrere feltet til LocalDateTime for å unngå slalåm, komplisert nok dette.
+                var filterFomDager = LocalDate.now().plusDays(oppgavespørring.getFiltrerFra());
+                if (Objects.equals(KøSortering.FØRSTE_STØNADSDAG, oppgavespørring.getSortering())) {
+                    parameters.put("filterFomDager", filterFomDager);
+                } else {
+                    // vi inkluderer hele dagen når vi er på LocalDateTime-varianten (dvs øvrige KøSorteringer)
+                    parameters.put("filterFomDager", filterFomDager.atStartOfDay());
+                }
+            }
+            if (oppgavespørring.getFiltrerTil() != null) {
+                var filterTomDager = LocalDate.now().plusDays(oppgavespørring.getFiltrerTil());
+                if (Objects.equals(KøSortering.FØRSTE_STØNADSDAG, oppgavespørring.getSortering())) {
+                    parameters.put("filterTomDager", filterTomDager);
+                } else {
+                    // det er til og med
+                    parameters.put("filterTomDager", filterTomDager.atTime(LocalTime.MAX));
+                }
+            }
+
+            // så den statiske varianten med absolutte datoer
+            if (oppgavespørring.getFiltrerFomDato() != null) {
+                var filterFomDato = oppgavespørring.getFiltrerFomDato();
+                if (Objects.equals(KøSortering.FØRSTE_STØNADSDAG, oppgavespørring.getSortering())) {
+                    parameters.put("filterFomDato", filterFomDato);
+                } else {
+                    parameters.put("filterFomDato", filterFomDato.atTime(LocalTime.MIN));
+                }
+            }
+            if (oppgavespørring.getFiltrerTomDato() != null) {
+                var filterTomDato = oppgavespørring.getFiltrerTomDato();
+                if (Objects.equals(KøSortering.FØRSTE_STØNADSDAG, oppgavespørring.getSortering())) {
+                    parameters.put("filterTomDato", filterTomDato);
+                } else {
+                    parameters.put("filterTomDato", filterTomDato.atTime(LocalTime.MIN));
+                }
+            }
+        }
+
+        // TODO: slå sammen oppsett her med parameteroppsett over
+        if (KøSortering.BEHANDLINGSFRIST.equals(sortering)) {
+            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(BEHANDLINGSFRIST_FELT_SQL, oppgavespørring.getFiltrerFra(),
+                oppgavespørring.getFiltrerTil()) : filtrerStatisk(BEHANDLINGSFRIST_FELT_SQL, oppgavespørring.getFiltrerFomDato(),
+                oppgavespørring.getFiltrerTomDato());
+        }
+        if (KøSortering.OPPRETT_BEHANDLING.equals(sortering)) {
+            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(BEHANDLINGOPPRETTET_FELT_SQL, oppgavespørring.getFiltrerFra(),
+                oppgavespørring.getFiltrerTil()) : filtrerStatisk(BEHANDLINGOPPRETTET_FELT_SQL, oppgavespørring.getFiltrerFomDato(),
+                oppgavespørring.getFiltrerTomDato());
+        }
+        if (KøSortering.FØRSTE_STØNADSDAG.equals(sortering)) {
+            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(FØRSTE_STØNADSDAG_FELT_SQL, oppgavespørring.getFiltrerFra(),
+                oppgavespørring.getFiltrerTil()) : filtrerStatisk(FØRSTE_STØNADSDAG_FELT_SQL, oppgavespørring.getFiltrerFomDato(),
+                oppgavespørring.getFiltrerTomDato());
+        }
+        if (KøSortering.BELØP.equals(sortering)) {
+            return filtrerNumerisk(BELØP_FELT_SQL, oppgavespørring.getFiltrerFra(), oppgavespørring.getFiltrerTil());
+        }
+        if (KøSortering.FEILUTBETALINGSTART.equals(sortering)) {
+            if (oppgavespørring.isErDynamiskPeriode()) {
+                return filtrerDynamisk(FEILUTBETALINGSTART_FELT_SQL, oppgavespørring.getFiltrerFra(), oppgavespørring.getFiltrerTil());
+            } else {
+                return filtrerStatisk(FEILUTBETALINGSTART_FELT_SQL, oppgavespørring.getFiltrerFomDato(), oppgavespørring.getFiltrerTomDato());
+            }
+        }
+        return ORDER_BY_SQL + BEHANDLINGOPPRETTET_FELT_SQL;
+    }
+
+    private static String filtrerNumerisk(String felt, Long fra, Long til) {
+        var numeriskFiltrering = "";
+        if (fra != null && til != null) {
+            numeriskFiltrering = "AND " + felt + " BETWEEN :filterFra AND :filterTil ";
+        } else if (fra != null) {
+            numeriskFiltrering = "AND " + felt + " >= :filterFra ";
+        } else if (til != null) {
+            numeriskFiltrering = "AND " + felt + " <= :filterTil ";
+        }
+        return numeriskFiltrering + ORDER_BY_SQL + felt + DESC_SQL;
+    }
+
+    private static String filtrerDynamisk(String felt, Long fomDager, Long tomDager) {
+        var datoFiltrering = "";
+        if (fomDager != null && tomDager != null) {
+            datoFiltrering = "AND " + felt + " BETWEEN :filterFomDager AND :filterTomDager ";
+        } else if (fomDager != null) {
+            datoFiltrering = "AND " + felt + " > :filterFomDager ";
+        } else if (tomDager != null) {
+            datoFiltrering = "AND " + felt + " < :filterTomDager ";
+        }
+        return datoFiltrering + ORDER_BY_SQL + felt;
+    }
+
+    private static String filtrerStatisk(String felt, LocalDate fomDato, LocalDate tomDato) {
+        var datoFiltrering = "";
+        if (fomDato != null && tomDato != null) {
+            datoFiltrering = "AND " + felt + " BETWEEN :filterFomDato AND :filterTomDato ";
+        }  if (fomDato != null) {
+            datoFiltrering += "AND " + felt + " >= :filterFomDato ";
+        }  if (tomDato != null) {
+            datoFiltrering += "AND " + felt + " <= :filterTomDato ";
+        }
+        return datoFiltrering + ORDER_BY_SQL + felt;
+    }
+}

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepository.java
@@ -1,17 +1,11 @@
 package no.nav.foreldrepenger.los.oppgave;
 
 
-import static no.nav.foreldrepenger.los.oppgavekø.KøSortering.FT_DATO;
-import static no.nav.foreldrepenger.los.oppgavekø.KøSortering.FT_HELTALL;
-
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -27,7 +21,6 @@ import jakarta.persistence.TypedQuery;
 import no.nav.foreldrepenger.los.domene.typer.BehandlingId;
 import no.nav.foreldrepenger.los.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.los.felles.BaseEntitet;
-import no.nav.foreldrepenger.los.felles.util.BrukerIdent;
 import no.nav.foreldrepenger.los.hendelse.hendelsehåndterer.oppgaveeventlogg.OppgaveEventLogg;
 import no.nav.foreldrepenger.los.oppgavekø.KøSortering;
 import no.nav.foreldrepenger.los.oppgavekø.OppgaveFiltrering;
@@ -39,19 +32,12 @@ public class OppgaveRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(OppgaveRepository.class);
 
-    private static final String COUNT_FRA_OPPGAVE = "SELECT count(1) from Oppgave o ";
+    static final String COUNT_FRA_OPPGAVE = "SELECT count(1) from Oppgave o ";
     private static final String SELECT_FRA_OPPGAVE = "SELECT o from Oppgave o ";
-    private static final String COUNT_FRA_TILBAKEKREVING_OPPGAVE = "SELECT count(1) from TilbakekrevingOppgave o ";
+    static final String COUNT_FRA_TILBAKEKREVING_OPPGAVE = "SELECT count(1) from TilbakekrevingOppgave o ";
     private static final String SELECT_FRA_TILBAKEKREVING_OPPGAVE = "SELECT o from TilbakekrevingOppgave o ";
 
-    private static final String SORTERING = "ORDER BY ";
-    private static final String SYNKENDE_REKKEFØLGE = " DESC";
-    private static final String BEHANDLINGSFRIST = "o.behandlingsfrist";
-    private static final String BEHANDLINGOPPRETTET = "o.behandlingOpprettet";
-    private static final String FØRSTE_STØNADSDAG = "o.førsteStønadsdag";
-    private static final String BELØP = "o.belop";
-    private static final String FEILUTBETALINGSTART = "o.feilutbetalingstart";
-    private static final String BEHANDLING_ID = "behandlingId";
+    public static final String BEHANDLING_ID_FELT_SQL = "behandlingId";
 
     private EntityManager entityManager;
 
@@ -89,186 +75,8 @@ public class OppgaveRepository {
         return query.getResultList();
     }
 
-    private static String andreKriterierSubquery(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
-        var inkluderAkt = queryDto.getInkluderAndreKriterierTyper();
-        var ekskluderAkt = queryDto.getEkskluderAndreKriterierTyper();
-
-        var sb = new StringBuilder();
-        if (!inkluderAkt.isEmpty()) {
-            parameters.put("inkluderAktKoder", inkluderAkt);
-            parameters.put("inkluderAktAntall", inkluderAkt.size());
-            sb.append(" AND :inkluderAktAntall = (")
-                .append("   SELECT COUNT(oe.andreKriterierType) ")
-                .append("   FROM OppgaveEgenskap oe ")
-                .append("   WHERE oe.oppgave = o ")
-                .append("     AND oe.andreKriterierType IN (:inkluderAktKoder)")
-                .append(" ) ");
-        }
-        if (!ekskluderAkt.isEmpty()) {
-            parameters.put("ekskluderAktKoder", ekskluderAkt);
-            sb.append("AND NOT EXISTS ( ")
-                .append("SELECT 1 FROM OppgaveEgenskap oe ")
-                .append("WHERE oe.oppgave = o AND oe.andreKriterierType IN (:ekskluderAktKoder)")
-                .append(") ");
-        }
-
-        return sb.toString();
-    }
-
-    private static String filtrerBehandlingType(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
-        if (queryDto.getBehandlingTyper().isEmpty()) {
-            return "";
-        }
-        parameters.put("behtyper", queryDto.getBehandlingTyper());
-        return "AND o.behandlingType in :behtyper ";
-    }
-
-    private static String filtrerYtelseType(Oppgavespørring queryDto, HashMap<String, Object> parameters) {
-        if (queryDto.getYtelseTyper().isEmpty()) {
-            return "";
-        }
-        parameters.put("fagsakYtelseType", queryDto.getYtelseTyper());
-        return "AND o.fagsakYtelseType in :fagsakYtelseType ";
-    }
-
     private <T> TypedQuery<T> lagOppgavespørring(String selection, Class<T> resultClass, Oppgavespørring queryDto) {
-        var parameters = new HashMap<String, Object>();
-        parameters.put("enhetsnummer", queryDto.getEnhetsnummer());
-        var sb = new StringBuilder();
-        sb.append(selection);
-        sb.append(" WHERE o.behandlendeEnhet = :enhetsnummer ");
-        sb.append(filtrerBehandlingType(queryDto, parameters));
-        sb.append(filtrerYtelseType(queryDto, parameters));
-        sb.append(andreKriterierSubquery(queryDto, parameters));
-        sb.append(reserverteSubquery(parameters));
-        sb.append(tilBeslutter(queryDto, parameters));
-        sb.append(" AND o.aktiv = true ");
-        sb.append(sortering(selection, queryDto, parameters));
-
-        //var query = entityManager.createQuery(selection + //$NON-NLS-1$ // NOSONAR
-       //     " WHERE o.behandlendeEnhet = :enhetsnummer " + filtrerBehandlingType(queryDto) + filtrerYtelseType(queryDto)
-       //     + andreKriterierSubquery(queryDto) + reserverteSubquery(queryDto) + tilBeslutter(queryDto)
-       //     + "AND o.aktiv = true " + sortering(selection, queryDto), oppgaveClass);
-        var query = entityManager.createQuery(sb.toString(), resultClass);
-        parameters.forEach(query::setParameter);
-
-        return query;
-    }
-
-    private String sortering(String selection, Oppgavespørring oppgavespørring, HashMap<String, Object> parameters) {
-        if (selection.equals(COUNT_FRA_OPPGAVE) || selection.equals(COUNT_FRA_TILBAKEKREVING_OPPGAVE)) {
-            return "";
-        }
-        var sortering = oppgavespørring.getSortering();
-        if (FT_HELTALL.equalsIgnoreCase(oppgavespørring.getSortering().getFelttype())) {
-            if (oppgavespørring.getFiltrerFra() != null) {
-                parameters.put("filterFra", BigDecimal.valueOf(oppgavespørring.getFiltrerFra()));
-            }
-            if (oppgavespørring.getFiltrerTil() != null) {
-                parameters.put("filterTil", BigDecimal.valueOf(oppgavespørring.getFiltrerTil()));
-            }
-        } else if (FT_DATO.equalsIgnoreCase(oppgavespørring.getSortering().getFelttype())) {
-            if (oppgavespørring.getFiltrerFra() != null) {
-                parameters.put("filterFomDager", KøSortering.FØRSTE_STØNADSDAG.equals(oppgavespørring.getSortering()) ? LocalDate.now()
-                    .plusDays(oppgavespørring.getFiltrerFra()) : LocalDateTime.now().plusDays(oppgavespørring.getFiltrerFra()).with(LocalTime.MIN));
-            }
-            if (oppgavespørring.getFiltrerTil() != null) {
-                parameters.put("filterTomDager", KøSortering.FØRSTE_STØNADSDAG.equals(oppgavespørring.getSortering()) ? LocalDate.now()
-                    .plusDays(oppgavespørring.getFiltrerTil()) : LocalDateTime.now().plusDays(oppgavespørring.getFiltrerTil()).with(LocalTime.MAX));
-            }
-            if (oppgavespørring.getFiltrerFomDato() != null) {
-                parameters.put("filterFomDato", KøSortering.FØRSTE_STØNADSDAG.equals(
-                    oppgavespørring.getSortering()) ? oppgavespørring.getFiltrerFomDato() : oppgavespørring.getFiltrerFomDato()
-                    .atTime(LocalTime.MIN));
-            }
-            if (oppgavespørring.getFiltrerTomDato() != null) {
-                parameters.put("filterTomDato", KøSortering.FØRSTE_STØNADSDAG.equals(
-                    oppgavespørring.getSortering()) ? oppgavespørring.getFiltrerTomDato() : oppgavespørring.getFiltrerTomDato()
-                    .atTime(LocalTime.MAX));
-            }
-        }
-
-        if (KøSortering.BEHANDLINGSFRIST.equals(sortering)) {
-            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(BEHANDLINGSFRIST, oppgavespørring.getFiltrerFra(),
-                oppgavespørring.getFiltrerTil()) : filtrerStatisk(BEHANDLINGSFRIST, oppgavespørring.getFiltrerFomDato(),
-                oppgavespørring.getFiltrerTomDato());
-        }
-        if (KøSortering.OPPRETT_BEHANDLING.equals(sortering)) {
-            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(BEHANDLINGOPPRETTET, oppgavespørring.getFiltrerFra(),
-                oppgavespørring.getFiltrerTil()) : filtrerStatisk(BEHANDLINGOPPRETTET, oppgavespørring.getFiltrerFomDato(),
-                oppgavespørring.getFiltrerTomDato());
-        }
-        if (KøSortering.FØRSTE_STØNADSDAG.equals(sortering)) {
-            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(FØRSTE_STØNADSDAG, oppgavespørring.getFiltrerFra(),
-                oppgavespørring.getFiltrerTil()) : filtrerStatisk(FØRSTE_STØNADSDAG, oppgavespørring.getFiltrerFomDato(),
-                oppgavespørring.getFiltrerTomDato());
-        }
-        if (KøSortering.BELØP.equals(sortering)) {
-            return filtrerNumerisk(BELØP, oppgavespørring.getFiltrerFra(), oppgavespørring.getFiltrerTil());
-        }
-        if (KøSortering.FEILUTBETALINGSTART.equals(sortering)) {
-            return oppgavespørring.isErDynamiskPeriode() ? filtrerDynamisk(FEILUTBETALINGSTART, oppgavespørring.getFiltrerFra(),
-                oppgavespørring.getFiltrerTil()) : filtrerStatisk(FEILUTBETALINGSTART, oppgavespørring.getFiltrerFomDato(),
-                oppgavespørring.getFiltrerTomDato());
-        }
-        return SORTERING + BEHANDLINGOPPRETTET;
-    }
-
-    private static String reserverteSubquery(HashMap<String, Object> parameters) {
-        parameters.put("nå", LocalDateTime.now());
-        return "AND NOT EXISTS (select r from Reservasjon r where r.oppgave = o and r.reservertTil > :nå) ";
-    }
-
-    private static String tilBeslutter(Oppgavespørring dto, HashMap<String, Object> parameters) {
-        var tilBeslutterKø = dto.getInkluderAndreKriterierTyper().contains(AndreKriterierType.TIL_BESLUTTER);
-        if (dto.getForAvdelingsleder() || !tilBeslutterKø) {
-            return "";
-        }
-        parameters.put("tilbeslutter", AndreKriterierType.TIL_BESLUTTER);
-        parameters.put("uid", BrukerIdent.brukerIdent());
-        return """
-            AND NOT EXISTS (
-                select oetilbesl.oppgave from OppgaveEgenskap oetilbesl
-                where oetilbesl.oppgave = o
-                    AND oetilbesl.andreKriterierType = :tilbeslutter
-                    AND upper(oetilbesl.sisteSaksbehandlerForTotrinn) = :uid
-            )""";
-    }
-
-    private String filtrerNumerisk(String sortering, Long fra, Long til) {
-        var numeriskFiltrering = "";
-        if (fra != null && til != null) {
-            numeriskFiltrering = "AND " + sortering + " >= :filterFra AND " + sortering + " <= :filterTil ";
-        } else if (fra != null) {
-            numeriskFiltrering = "AND " + sortering + " >= :filterFra ";
-        } else if (til != null) {
-            numeriskFiltrering = "AND " + sortering + " <= :filterTil ";
-        }
-        return numeriskFiltrering + SORTERING + sortering + SYNKENDE_REKKEFØLGE;
-    }
-
-    private String filtrerDynamisk(String sortering, Long fomDager, Long tomDager) {
-        var datoFiltrering = "";
-        if (fomDager != null && tomDager != null) {
-            datoFiltrering = "AND " + sortering + " > :filterFomDager AND " + sortering + " < :filterTomDager ";
-        } else if (fomDager != null) {
-            datoFiltrering = "AND " + sortering + " > :filterFomDager ";
-        } else if (tomDager != null) {
-            datoFiltrering = "AND " + sortering + " < :filterTomDager ";
-        }
-        return datoFiltrering + SORTERING + sortering;
-    }
-
-    private String filtrerStatisk(String sortering, LocalDate fomDato, LocalDate tomDato) {
-        var datoFiltrering = "";
-        if (fomDato != null && tomDato != null) {
-            datoFiltrering = "AND " + sortering + " >= :filterFomDato AND " + sortering + " <= :filterTomDato ";
-        } else if (fomDato != null) {
-            datoFiltrering = "AND " + sortering + " >= :filterFomDato ";
-        } else if (tomDato != null) {
-            datoFiltrering = "AND " + sortering + " <= :filterTomDato ";
-        }
-        return datoFiltrering + SORTERING + sortering;
+        return OppgaveQueryMapper.lagOppgavespørring(entityManager, selection, resultClass, queryDto);
     }
 
     public List<Oppgave> hentAktiveOppgaverForSaksnummer(Collection<Saksnummer> saksnummerListe) {
@@ -366,7 +174,7 @@ public class OppgaveRepository {
             from oppgaveEventLogg oel
             where oel.behandlingId = :behandlingId
             order by oel.opprettetTidspunkt desc
-            """, OppgaveEventLogg.class).setParameter(BEHANDLING_ID, behandlingId).getResultList();
+            """, OppgaveEventLogg.class).setParameter(BEHANDLING_ID_FELT_SQL, behandlingId).getResultList();
     }
 
     public List<OppgaveEgenskap> hentOppgaveEgenskaper(Long oppgaveId) {
@@ -380,7 +188,7 @@ public class OppgaveRepository {
     protected <T> List<T> hentOppgaver(BehandlingId behandlingId, Class<T> cls) {
         var select = cls.equals(TilbakekrevingOppgave.class) ? SELECT_FRA_TILBAKEKREVING_OPPGAVE : SELECT_FRA_OPPGAVE;
         return entityManager.createQuery(select + "WHERE o.behandlingId = :behandlingId", cls)
-            .setParameter(BEHANDLING_ID, behandlingId)
+            .setParameter(BEHANDLING_ID_FELT_SQL, behandlingId)
             .getResultList();
     }
 
@@ -441,7 +249,7 @@ public class OppgaveRepository {
 
     public List<Oppgave> hentOppgaver(BehandlingId behandlingId) {
         return entityManager.createQuery("FROM Oppgave o where o.behandlingId = :behandlingId", Oppgave.class)
-            .setParameter(BEHANDLING_ID, behandlingId)
+            .setParameter(BEHANDLING_ID_FELT_SQL, behandlingId)
             .getResultList();
     }
 
@@ -450,7 +258,7 @@ public class OppgaveRepository {
             FROM Oppgave o
             where o.behandlingId = :behandlingId
             and o.aktiv = :aktiv
-            """, Oppgave.class).setParameter(BEHANDLING_ID, behandlingId).setParameter("aktiv", true).getResultList();
+            """, Oppgave.class).setParameter(BEHANDLING_ID_FELT_SQL, behandlingId).setParameter("aktiv", true).getResultList();
         if (oppgaver.size() > 1) {
             LOG.warn("Flere enn én aktive oppgaver for behandlingId {}", behandlingId);
         }

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
@@ -12,7 +12,7 @@ import static java.util.function.Predicate.not;
 
 public class Oppgavespørring {
     private final KøSortering sortering;
-    private final Long enhetId;
+    private final String enhetsnummer;
     private final List<BehandlingType> behandlingTyper;
     private final List<FagsakYtelseType> ytelseTyper;
     private final List<AndreKriterierType> inkluderAndreKriterierTyper;
@@ -28,7 +28,7 @@ public class Oppgavespørring {
 
     public Oppgavespørring(OppgaveFiltrering oppgaveFiltrering) {
         sortering = oppgaveFiltrering.getSortering();
-        enhetId = oppgaveFiltrering.getAvdeling().getId();
+        enhetsnummer = oppgaveFiltrering.getAvdeling().getAvdelingEnhet();
         behandlingTyper = oppgaveFiltrering.getBehandlingTyper();
         ytelseTyper = oppgaveFiltrering.getFagsakYtelseTyper();
         inkluderAndreKriterierTyper = inkluderAndreKriterierTyperFra(oppgaveFiltrering);
@@ -40,7 +40,7 @@ public class Oppgavespørring {
         filtrerTil = oppgaveFiltrering.getTil();
     }
 
-    public Oppgavespørring(Long enhetId,
+    public Oppgavespørring(String enhetsnummer,
                            KøSortering sortering,
                            List<BehandlingType> behandlingTyper,
                            List<FagsakYtelseType> ytelseTyper,
@@ -52,7 +52,7 @@ public class Oppgavespørring {
                            Long filtrerFra,
                            Long filtrerTil) {
         this.sortering = sortering;
-        this.enhetId = enhetId;
+        this.enhetsnummer = enhetsnummer;
         this.behandlingTyper = behandlingTyper;
         this.ytelseTyper = ytelseTyper;
         this.inkluderAndreKriterierTyper = inkluderAndreKriterierTyper;
@@ -64,6 +64,7 @@ public class Oppgavespørring {
         this.filtrerTil = filtrerTil;
     }
 
+    // todo: fjern denne ubrukte greia
     public boolean ignorerReserversjoner() {
         return ignorerReserversjoner;
     }
@@ -88,8 +89,8 @@ public class Oppgavespørring {
         return sortering;
     }
 
-    public Long getEnhetId() {
-        return enhetId;
+    public String getEnhetsnummer() {
+        return enhetsnummer;
     }
 
     public List<BehandlingType> getBehandlingTyper() {
@@ -150,7 +151,7 @@ public class Oppgavespørring {
 
     @Override
     public String toString() {
-        return "Oppgavespørring{" + "sortering=" + sortering + ", enhetId=" + enhetId + ", behandlingTyper=" + behandlingTyper + ", ytelseTyper="
+        return "Oppgavespørring{" + "sortering=" + sortering + ", enhetsnummer=" + enhetsnummer + ", behandlingTyper=" + behandlingTyper + ", ytelseTyper="
             + ytelseTyper + ", inkluderAndreKriterierTyper=" + inkluderAndreKriterierTyper + ", ekskluderAndreKriterierTyper="
             + ekskluderAndreKriterierTyper + ", erDynamiskPeriode=" + erDynamiskPeriode + ", filtrerFomDato=" + filtrerFomDato + ", filtrerTomDato="
             + filtrerTomDato + ", filtrerFra=" + filtrerFra + ", filtrerTil=" + filtrerTil + ", forAvdelingsleder=" + forAvdelingsleder

--- a/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgave/Oppgavespørring.java
@@ -23,7 +23,6 @@ public class Oppgavespørring {
     private final Long filtrerFra;
     private final Long filtrerTil;
     private boolean forAvdelingsleder;
-    private boolean ignorerReserversjoner;
     private Long maxAntallOppgaver;
 
     public Oppgavespørring(OppgaveFiltrering oppgaveFiltrering) {
@@ -62,15 +61,6 @@ public class Oppgavespørring {
         this.filtrerTomDato = filtrerTomDato;
         this.filtrerFra = filtrerFra;
         this.filtrerTil = filtrerTil;
-    }
-
-    // todo: fjern denne ubrukte greia
-    public boolean ignorerReserversjoner() {
-        return ignorerReserversjoner;
-    }
-
-    public void setIgnorerReserversjoner(boolean ignorerReserversjoner) {
-        this.ignorerReserversjoner = ignorerReserversjoner;
     }
 
     public void setForAvdelingsleder(boolean forAvdelingsleder) {
@@ -151,7 +141,7 @@ public class Oppgavespørring {
 
     @Override
     public String toString() {
-        return "Oppgavespørring{" + "sortering=" + sortering + ", enhetsnummer=" + enhetsnummer + ", behandlingTyper=" + behandlingTyper + ", ytelseTyper="
+        return "Oppgavespørring{" + "sortering=" + sortering + "enhetsnummer=" + enhetsnummer + ", behandlingTyper=" + behandlingTyper + ", ytelseTyper="
             + ytelseTyper + ", inkluderAndreKriterierTyper=" + inkluderAndreKriterierTyper + ", ekskluderAndreKriterierTyper="
             + ekskluderAndreKriterierTyper + ", erDynamiskPeriode=" + erDynamiskPeriode + ", filtrerFomDato=" + filtrerFomDato + ", filtrerTomDato="
             + filtrerTomDato + ", filtrerFra=" + filtrerFra + ", filtrerTil=" + filtrerTil + ", forAvdelingsleder=" + forAvdelingsleder

--- a/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveKøTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/oppgavekø/OppgaveKøTjeneste.java
@@ -55,7 +55,7 @@ public class OppgaveKøTjeneste {
 
     public Integer hentAntallOppgaverForAvdeling(String avdelingsEnhet) {
         var avdeling = organisasjonRepository.hentAvdelingFraEnhet(avdelingsEnhet).orElseThrow();
-        return oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getId());
+        return oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getAvdelingEnhet());
     }
 
     public List<Oppgave> hentOppgaver(Long sakslisteId, int maksAntall) {

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTask.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/admin/SlettDeaktiverteAvdelingerTask.java
@@ -48,7 +48,7 @@ public class SlettDeaktiverteAvdelingerTask implements ProsessTaskHandler {
             return;
         }
 
-        var antallÅpneOppgaver = oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getId());
+        var antallÅpneOppgaver = oppgaveRepository.hentAntallOppgaverForAvdeling(avdeling.getAvdelingEnhet());
         if (antallÅpneOppgaver > 0) {
             LOG.warn("Fant {} aktive oppgaver tilknyttet enhetsnummer {}, avbryter avdelingssletting.", antallÅpneOppgaver, enhetsnummer);
             return;

--- a/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/oppgave/OppgaveRepositoryTest.java
@@ -66,7 +66,7 @@ class OppgaveRepositoryTest {
     }
 
     private Oppgavespørring oppgaverForDrammenSpørring() {
-        return new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false,
+        return new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false,
             null, null, null, null);
     }
 
@@ -109,7 +109,7 @@ class OppgaveRepositoryTest {
     @Test
     void testOppgaveSpørringMedEgenskaperfiltrering() {
         var saksnummerHit = setupOppgaveMedEgenskaper(AndreKriterierType.UTLANDSSAK, AndreKriterierType.UTBETALING_TIL_BRUKER);
-        var oppgaveQuery = new Oppgavespørring(avdelingIdForDrammen(), BEHANDLINGSFRIST, List.of(), List.of(), List.of(AndreKriterierType.UTLANDSSAK),
+        var oppgaveQuery = new Oppgavespørring(AVDELING_DRAMMEN_ENHET, BEHANDLINGSFRIST, List.of(), List.of(), List.of(AndreKriterierType.UTLANDSSAK),
             // inkluderes
             List.of(AndreKriterierType.VURDER_SYKDOM), // ekskluderes
             false, null, null, null, null);
@@ -121,47 +121,47 @@ class OppgaveRepositoryTest {
     @Test
     void testEkskluderingOgInkluderingAvOppgaver() {
         lagStandardSettMedOppgaver();
-        var oppgaver = oppgaveRepository.hentOppgaver(new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(),
+        var oppgaver = oppgaveRepository.hentOppgaver(new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(),
             List.of(AndreKriterierType.TIL_BESLUTTER, AndreKriterierType.PAPIRSØKNAD), new ArrayList<>(), false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.TIL_BESLUTTER),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.TIL_BESLUTTER),
                 new ArrayList<>(), false, null, null, null, null));
         assertThat(oppgaver).hasSize(2);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 List.of(AndreKriterierType.TIL_BESLUTTER, AndreKriterierType.PAPIRSØKNAD), // ekskluder andreKriterierType
                 false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 List.of(AndreKriterierType.TIL_BESLUTTER),  // ekskluderAndreKriterierType
                 false, null, null, null, null));
         assertThat(oppgaver).hasSize(2);
 
         oppgaver = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
                 List.of(AndreKriterierType.TIL_BESLUTTER), false, null, null, null, null));
         assertThat(oppgaver).hasSize(1);
         var antallOppgaver = oppgaveRepository.hentAntallOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), List.of(AndreKriterierType.PAPIRSØKNAD),
                 List.of(AndreKriterierType.TIL_BESLUTTER), false, null, null, null, null));
         assertThat(antallOppgaver).isEqualTo(1);
 
-        var antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(avdelingIdForDrammen());
+        var antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(AVDELING_DRAMMEN_ENHET);
         assertThat(antallOppgaverForAvdeling).isEqualTo(4);
 
     }
 
     @Test
     void testAntallOppgaverForAvdeling() {
-        var antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(avdelingIdForDrammen());
+        var antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(AVDELING_DRAMMEN_ENHET);
         assertThat(antallOppgaverForAvdeling).isZero();
         lagStandardSettMedOppgaver();
-        antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(avdelingIdForDrammen());
+        antallOppgaverForAvdeling = oppgaveRepository.hentAntallOppgaverForAvdeling(AVDELING_DRAMMEN_ENHET);
         assertThat(antallOppgaverForAvdeling).isEqualTo(4);
     }
 
@@ -169,7 +169,7 @@ class OppgaveRepositoryTest {
     void testFiltreringDynamiskAvOppgaverIntervall() {
         lagStandardSettMedOppgaver();
         var oppgaves = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 true, null, null, 1L, 10L));
         assertThat(oppgaves).hasSize(2);
     }
@@ -178,7 +178,7 @@ class OppgaveRepositoryTest {
     void testFiltreringDynamiskAvOppgaverBareFomDato() {
         lagStandardSettMedOppgaver();
         var oppgaves = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 true, null, null, 15L, null));
         assertThat(oppgaves).hasSize(1);
     }
@@ -187,7 +187,7 @@ class OppgaveRepositoryTest {
     void testFiltreringDynamiskAvOppgaverBareTomDato() {
         lagStandardSettMedOppgaver();
         var oppgaves = oppgaveRepository.hentOppgaver(
-            new Oppgavespørring(avdelingIdForDrammen(), BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+            new Oppgavespørring(AVDELING_DRAMMEN_ENHET, BEHANDLINGSFRIST, new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
                 true, null, null, null, 15L));
         assertThat(oppgaves).hasSize(4);
     }
@@ -326,7 +326,7 @@ class OppgaveRepositoryTest {
         oppgaveRepository.lagre(uaktuellOppgave);
         oppgaveRepository.lagre(aktuellOppgave);
         var filtrerTomDato = LocalDate.now().minusDays(1);
-        var query = new Oppgavespørring(avdelingIdForDrammen(), KøSortering.OPPRETT_BEHANDLING, List.of(BehandlingType.FØRSTEGANGSSØKNAD),
+        var query = new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.OPPRETT_BEHANDLING, List.of(BehandlingType.FØRSTEGANGSSØKNAD),
             List.of(FagsakYtelseType.FORELDREPENGER), List.of(), List.of(), false, //erDynamiskPeriode
             null, filtrerTomDato, null, null);
         var oppgaveResultat = oppgaveRepository.hentOppgaver(query);
@@ -348,7 +348,7 @@ class OppgaveRepositoryTest {
     }
 
     private List<Oppgave> filterOppgaver(LocalDate filtrerFomDato, LocalDate filtrerTomDato) {
-        var query = new Oppgavespørring(avdelingIdForDrammen(), KøSortering.FØRSTE_STØNADSDAG, List.of(), List.of(), List.of(), List.of(), false,
+        var query = new Oppgavespørring(AVDELING_DRAMMEN_ENHET, KøSortering.FØRSTE_STØNADSDAG, List.of(), List.of(), List.of(), List.of(), false,
             filtrerFomDato, filtrerTomDato, null, null);
         return oppgaveRepository.hentOppgaver(query);
     }
@@ -372,7 +372,7 @@ class OppgaveRepositoryTest {
         oppgaveRepository.lagre(oppgaveUtenStartDato);
         oppgaveRepository.lagre(oppgaveMedStartDato);
 
-        var query = new Oppgavespørring(avdelingIdForDrammen(), FEILUTBETALINGSTART, List.of(), List.of(), List.of(), // inkluderes
+        var query = new Oppgavespørring(AVDELING_DRAMMEN_ENHET, FEILUTBETALINGSTART, List.of(), List.of(), List.of(), // inkluderes
             List.of(), //ekskluderes
             false, null, null, null, null);
         var oppgaver = oppgaveRepository.hentOppgaver(query);


### PR DESCRIPTION
Skiller ut delen som setter sammen JPQL for oppgavekøer til en egen OppgavespørringMapper-klasse. Et par forbedringer:

- Fjerner unødvendig join med Avdeling
- Flytter oppsett av sql-parametere slik at dette gjøres der relevant sql lages (tidligere duplisert logikk)
- Order by og filterfunksjoner på datoer/beløp var tidligere slått sammen. Skiller dette nå fra hverandre. Velger nå å eksplisitt unnlate order by ved select count(). Optimizer har antakelig ikke forholdt seg til order by i dette tilfellet, men det er tydeligere hva som skjer funksjonelt på denne måten.
- AndreKriterier-subquery er noe omskrevet. Dropper distinct og stoler på at vi ikke har duplikate oppgaveegenskaper
- Dropper tilBeslutter subquery dersom køen ikke eksplisitt er satt opp for å inkludere beslutteroppgaver. Dette subqueriet fjerner beslutteroppgaver dersom saksbehandler selv er den som har foreslått vedtak. Tenker dette passer med bruksmønsteret i enhetene.