### PR TITLE
TFP-6923: legg til køStatistikk-endepunkt for saksbehandler

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/konfig/ApiConfig.java
+++ b/src/main/java/no/nav/foreldrepenger/los/konfig/ApiConfig.java
@@ -73,6 +73,7 @@ public class ApiConfig extends Application {
         classes.add(AvdelingReservasjonerRestTjeneste.class);
         classes.add(ReservasjonRestTjeneste.class);
         classes.add(NøkkeltallRestTjeneste.class);
+        classes.add(no.nav.foreldrepenger.los.tjenester.saksbehandler.nøkkeltall.NøkkeltallRestTjeneste.class);
         classes.add(AvdelingslederRestTjeneste.class);
         classes.add(AvdelingslederOppgaveRestTjeneste.class);
         return classes;

--- a/src/main/java/no/nav/foreldrepenger/los/konfig/ApiConfig.java
+++ b/src/main/java/no/nav/foreldrepenger/los/konfig/ApiConfig.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import no.nav.foreldrepenger.los.tjenester.saksbehandler.nøkkeltall.SaksbehandlerNøkkeltallRestTjeneste;
 import org.glassfish.jersey.server.ServerProperties;
 
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
@@ -73,7 +74,7 @@ public class ApiConfig extends Application {
         classes.add(AvdelingReservasjonerRestTjeneste.class);
         classes.add(ReservasjonRestTjeneste.class);
         classes.add(NøkkeltallRestTjeneste.class);
-        classes.add(no.nav.foreldrepenger.los.tjenester.saksbehandler.nøkkeltall.NøkkeltallRestTjeneste.class);
+        classes.add(SaksbehandlerNøkkeltallRestTjeneste.class);
         classes.add(AvdelingslederRestTjeneste.class);
         classes.add(AvdelingslederOppgaveRestTjeneste.class);
         return classes;

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/NøkkeltallRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/NøkkeltallRestTjeneste.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -16,6 +17,7 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import no.nav.foreldrepenger.los.statistikk.KøStatistikkDto;
 import no.nav.foreldrepenger.los.statistikk.StatistikkRepository;
+import no.nav.foreldrepenger.los.tjenester.felles.dto.SakslisteIdDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
@@ -44,6 +46,17 @@ public class NøkkeltallRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public List<KøStatistikkDto> aktiveOgTilgjengligeOppgaverStatistikkForKø(@QueryParam(ENHET_QUERY_NAME) @NotNull @Valid Long oppgaveFilterId) {
         return statistikkRepository.hentStatistikkOppgaveFilterFraFom(oppgaveFilterId, LocalDate.now().minusMonths(1)).stream()
+            .map(no.nav.foreldrepenger.los.tjenester.avdelingsleder.nøkkeltall.NøkkeltallRestTjeneste::tilDto)
+            .sorted(Comparator.comparing(KøStatistikkDto::tidspunkt))
+            .toList();
+    }
+
+    @GET
+    @Path("/statistikk-oppgave-filter")
+    @Operation(description = "Hent køstatistikk for saksbehandlers saksliste den siste måneden")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
+    public List<KøStatistikkDto> køStatistikkForSaksliste(@QueryParam("sakslisteId") @NotNull @Valid SakslisteIdDto sakslisteId) {
+        return statistikkRepository.hentStatistikkOppgaveFilterFraFom(sakslisteId.getVerdi(), LocalDate.now().minusMonths(1)).stream()
             .map(no.nav.foreldrepenger.los.tjenester.avdelingsleder.nøkkeltall.NøkkeltallRestTjeneste::tilDto)
             .sorted(Comparator.comparing(KøStatistikkDto::tidspunkt))
             .toList();

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/NøkkeltallRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/NøkkeltallRestTjeneste.java
@@ -28,8 +28,6 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Transactional
 public class NøkkeltallRestTjeneste {
 
-    private static final String ENHET_QUERY_NAME = "oppgaveFilterId";
-
     private StatistikkRepository statistikkRepository;
 
     public NøkkeltallRestTjeneste() {
@@ -42,24 +40,14 @@ public class NøkkeltallRestTjeneste {
     }
 
     @GET
-    @Path("/oppgaver")
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
-    public List<KøStatistikkDto> aktiveOgTilgjengligeOppgaverStatistikkForKø(@QueryParam(ENHET_QUERY_NAME) @NotNull @Valid Long oppgaveFilterId) {
-        return statistikkRepository.hentStatistikkOppgaveFilterFraFom(oppgaveFilterId, LocalDate.now().minusMonths(1)).stream()
-            .map(no.nav.foreldrepenger.los.tjenester.avdelingsleder.nøkkeltall.NøkkeltallRestTjeneste::tilDto)
-            .sorted(Comparator.comparing(KøStatistikkDto::tidspunkt))
-            .toList();
-    }
-
-    @GET
     @Path("/statistikk-oppgave-filter")
     @Operation(description = "Hent køstatistikk for saksbehandlers saksliste den siste måneden")
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public List<KøStatistikkDto> køStatistikkForSaksliste(@QueryParam("sakslisteId") @NotNull @Valid SakslisteIdDto sakslisteId) {
         return statistikkRepository.hentStatistikkOppgaveFilterFraFom(sakslisteId.getVerdi(), LocalDate.now().minusMonths(1)).stream()
-            .map(no.nav.foreldrepenger.los.tjenester.avdelingsleder.nøkkeltall.NøkkeltallRestTjeneste::tilDto)
-            .sorted(Comparator.comparing(KøStatistikkDto::tidspunkt))
-            .toList();
+                .map(no.nav.foreldrepenger.los.tjenester.avdelingsleder.nøkkeltall.NøkkeltallRestTjeneste::tilDto)
+                .sorted(Comparator.comparing(KøStatistikkDto::tidspunkt))
+                .toList();
     }
 
 }

--- a/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/SaksbehandlerNøkkeltallRestTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/los/tjenester/saksbehandler/nøkkeltall/SaksbehandlerNøkkeltallRestTjeneste.java
@@ -26,16 +26,16 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Produces(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 @Transactional
-public class NøkkeltallRestTjeneste {
+public class SaksbehandlerNøkkeltallRestTjeneste {
 
     private StatistikkRepository statistikkRepository;
 
-    public NøkkeltallRestTjeneste() {
+    public SaksbehandlerNøkkeltallRestTjeneste() {
         // For Rest-CDI
     }
 
     @Inject
-    public NøkkeltallRestTjeneste(StatistikkRepository statistikkRepository) {
+    public SaksbehandlerNøkkeltallRestTjeneste(StatistikkRepository statistikkRepository) {
         this.statistikkRepository = statistikkRepository;
     }
 


### PR DESCRIPTION
## TFP-6923

Legger til GET-endepunkt for statistikk igjen

`GET /fplos/api/saksbehandler/nøkkeltall/statistikk-oppgave-filter?sakslisteId={id}`

Returnerer `List<KøStatistikkDto>` for siste måned basert på sakslisteId. Skal brukes av `AvsluttedeOppgaverDialog` i fp-frontend for å vise graf over avsluttede oppgaver per kø i los