### PR TITLE
Gcp-migrering: lager ny prosesstask ved terskelverdi

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/los/migrering/fss/FssEksportRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/los/migrering/fss/FssEksportRepository.java
@@ -75,7 +75,8 @@ public class FssEksportRepository {
             .setHint(HibernateHints.HINT_READ_ONLY, true)
             .setFirstResult(startPosisjon)
             .setMaxResults(batchSize)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .map(FssExportMapper::mapToOppgaveDataDto)
             .toList();
 
@@ -99,7 +100,8 @@ public class FssEksportRepository {
             .setParameter("avsluttetTid", LocalDate.now().minusDays(1).atStartOfDay())
             .setFirstResult(startPosisjon)
             .setMaxResults(batchSize)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .map(FssExportMapper::mapToOppgaveDataDto)
             .toList();
         var dto = BulkDataWrapper.inaktiveOppgaver(oppgaver);
@@ -129,7 +131,8 @@ public class FssEksportRepository {
                 "FROM BehandlingEgenskap WHERE behandlingId IN :ids", BehandlingEgenskap.class)
             .setHint(HibernateHints.HINT_READ_ONLY, true)
             .setParameter("ids", behandlingIds)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .collect(groupingBy(BehandlingEgenskap::getBehandlingId,
                 mapping(BehandlingEgenskap::getAndreKriterierType, toSet())));
 
@@ -189,7 +192,8 @@ public class FssEksportRepository {
                 .setHint(HibernateHints.HINT_READ_ONLY, true)
                 .setFirstResult(startPosisjon)
                 .setMaxResults(batchSize)
-                .getResultStream()
+                .getResultList()
+                .stream()
                 .map(FssExportMapper::mapToStatEnhetYtelseBehandlingDataDto)
                 .toList();
 
@@ -202,7 +206,8 @@ public class FssEksportRepository {
             .setParameter("fra", LocalDate.now().minusWeeks(4))
             .setFirstResult(startPosisjon)
             .setMaxResults(batchSize)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .map(FssExportMapper::mapToStatOppgaveFilterDataDto)
             .toList();
         return BulkDataWrapper.statistikkOppgaveFilter(oppgaveFilter);
@@ -212,13 +217,15 @@ public class FssEksportRepository {
         var oppgaveFiltreringSaksbehandleridenter = entityManager.createQuery("FROM FiltreringSaksbehandlerRelasjon",
                 FiltreringSaksbehandlerRelasjon.class)
             .setHint(HibernateHints.HINT_READ_ONLY, true)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .collect(Collectors.groupingBy(fsr -> fsr.getOppgaveFiltrering().getId(),
                 mapping(fsr -> fsr.getSaksbehandler().getSaksbehandlerIdent(), toSet())));
 
         return entityManager.createQuery("FROM OppgaveFiltrering", OppgaveFiltrering.class)
             .setHint(HibernateHints.HINT_READ_ONLY, true)
-            .getResultStream()
+            .getResultList()
+            .stream()
             .map(of -> FssExportMapper.mapToOppgaveFiltreringDataDto(of, oppgaveFiltreringSaksbehandleridenter))
             .toList();
     }

--- a/src/main/java/no/nav/foreldrepenger/los/migrering/fss/FssGcpMigrasjonTask.java
+++ b/src/main/java/no/nav/foreldrepenger/los/migrering/fss/FssGcpMigrasjonTask.java
@@ -7,7 +7,6 @@ import org.slf4j.LoggerFactory;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.los.migrering.dto.BulkDataWrapper;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -18,9 +17,14 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 @ProsessTask(value = "vedlikehold.migrerfssgcp", maxFailedRuns = 1)
 public class FssGcpMigrasjonTask implements ProsessTaskHandler {
 
+    private static final Logger LOG = LoggerFactory.getLogger(FssGcpMigrasjonTask.class);
+
+    private static final int ITERASJON_BULK_STØRRELSE = 100;
+    private static final int PROSESSTASK_MAKS_ANTALL = 2_000;
+
+    public static final String START_POSISJON = "START_POSISJON";
     public static final String STEG = "CURRENT_MIGRASJONSTEG";
 
-    private static final Logger LOG = LoggerFactory.getLogger(FssGcpMigrasjonTask.class);
 
     private final FssEksportRepository fssEksportRepository;
     private final GcpLosKlient gcpLosKlient;
@@ -36,42 +40,53 @@ public class FssGcpMigrasjonTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        if (Environment.current().isGcp()) {
-            throw new IllegalStateException("MIGRERING: FSS-task startet i GCP!");
-        }
-
-        var currentSteg = Optional.ofNullable(prosessTaskData.getPropertyValue(STEG))
+        var currentMigreringSteg = Optional.ofNullable(prosessTaskData.getPropertyValue(STEG))
             .map(MigreringSteg::valueOf)
             .orElse(MigreringSteg.DEL1_ORGANISASJON_OG_KØ);
-        int batchSize = 100;
 
-        LOG.info("MIGRERING (FSS): steg {} starter", currentSteg);
+        int startPosisjon = Optional.ofNullable(prosessTaskData.getPropertyValue(START_POSISJON))
+            .map(Integer::parseInt)
+            .orElse(0);
+        int antallHentetDenneTasken = 0;
 
-        int startPosisjon = 0;
+        LOG.info("MIGRERING (FSS): steg {} starter fra startPosisjon {}", currentMigreringSteg, startPosisjon);
 
-        // Gjør dette enkelt med én taskkjøring per relaterte entiteter
         while (true) {
-            var bulkData = currentSteg.hent(fssEksportRepository, startPosisjon, batchSize);
+            var bulkData = currentMigreringSteg.hent(fssEksportRepository, startPosisjon, ITERASJON_BULK_STØRRELSE);
+
             gcpLosKlient.lagreBulkData(bulkData);
 
-            var antallHentet = currentSteg.hentetAntall(bulkData);
-            logg(currentSteg, startPosisjon, antallHentet, batchSize);
+            int antallHentetIterasjon = currentMigreringSteg.hentetAntall(bulkData);
+            startPosisjon += antallHentetIterasjon;
+            antallHentetDenneTasken += antallHentetIterasjon;
 
-            if (currentSteg.erFerdig(antallHentet, batchSize)) {
-                lagNesteSteg(currentSteg);
+            logg(currentMigreringSteg, startPosisjon, antallHentetDenneTasken);
+
+            if (currentMigreringSteg.erFerdig(antallHentetIterasjon, ITERASJON_BULK_STØRRELSE)) {
+                lagTaskNesteSteg(currentMigreringSteg);
                 break;
-            } else {
-                startPosisjon += antallHentet;
+            }
+
+            if (antallHentetDenneTasken >= PROSESSTASK_MAKS_ANTALL) {
+                lagTaskFortsetterSammeSteg(currentMigreringSteg, startPosisjon);
+                break;
             }
         }
     }
 
-    private void logg(MigreringSteg currentSteg, int startPosisjon, int antallHentet, int batchSize) {
-        LOG.info("MIGRERING (FSS): steg {}, startPosisjon {}, antallHentet {}, batchSize {}",
-            currentSteg, startPosisjon, antallHentet, batchSize);
+    private void logg(MigreringSteg currentSteg, int startPosisjon, int antallHentetDenneTasken) {
+        LOG.info("MIGRERING (FSS): steg {}, neste startPosisjon {}, antallHentetDenneTasken {}", currentSteg, startPosisjon, antallHentetDenneTasken);
     }
 
-    private void lagNesteSteg(MigreringSteg currentSteg) {
+    private void lagTaskFortsetterSammeSteg(MigreringSteg currentSteg, int startPosisjon) {
+        LOG.info("MIGRERING (FSS): steg {} ikke ferdig, lagrer task for samme steg med startPosisjon {}", currentSteg, startPosisjon);
+        var t = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        t.setProperty(STEG, currentSteg.name());
+        t.setProperty(START_POSISJON, String.valueOf(startPosisjon));
+        prosessTaskTjeneste.lagre(t);
+    }
+
+    private void lagTaskNesteSteg(MigreringSteg currentSteg) {
         var nesteSteg = currentSteg.neste();
         LOG.info("MIGRERING (FSS): steg {} ferdig, neste steg {}", currentSteg, nesteSteg);
         if (nesteSteg != MigreringSteg.DEL7_FERDIG) {

--- a/src/test/java/no/nav/foreldrepenger/los/migrering/fss/FssGcpMigrasjonTaskTest.java
+++ b/src/test/java/no/nav/foreldrepenger/los/migrering/fss/FssGcpMigrasjonTaskTest.java
@@ -1,0 +1,169 @@
+package no.nav.foreldrepenger.los.migrering.fss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.los.migrering.dto.BehandlingDataDto;
+import no.nav.foreldrepenger.los.migrering.dto.BulkDataWrapper;
+import no.nav.foreldrepenger.los.migrering.dto.StatEnhetYtelseBehandlingDataDto;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ExtendWith(MockitoExtension.class)
+class FssGcpMigrasjonTaskTest {
+
+    @Mock
+    private FssEksportRepository fssEksportRepository;
+    @Mock
+    private GcpLosKlient gcpLosKlient;
+    @Mock
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+
+    private FssGcpMigrasjonTask task;
+
+    @BeforeEach
+    void setup() {
+        task = new FssGcpMigrasjonTask(fssEksportRepository, gcpLosKlient, prosessTaskTjeneste);
+    }
+
+
+    @Test
+    void skal_paginere_riktig_og_lage_neste_steg_task_nar_ferdig() {
+        when(fssEksportRepository.hentBehandlinger(anyInt(), eq(100)))
+            .thenReturn(behandlinger(100))
+            .thenReturn(behandlinger(100))
+            .thenReturn(behandlinger(40));
+
+        var data = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        data.setProperty(FssGcpMigrasjonTask.STEG, FssGcpMigrasjonTask.MigreringSteg.DEL2_BEHANDLINGER.name());
+
+        task.doTask(data);
+
+        InOrder inOrder = inOrder(fssEksportRepository);
+        inOrder.verify(fssEksportRepository).hentBehandlinger(0, 100);
+        inOrder.verify(fssEksportRepository).hentBehandlinger(100, 100);
+        inOrder.verify(fssEksportRepository).hentBehandlinger(200, 100);
+
+        verify(gcpLosKlient, times(3)).lagreBulkData(any());
+
+        var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(prosessTaskTjeneste).lagre(captor.capture());
+
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.STEG))
+            .isEqualTo(FssGcpMigrasjonTask.MigreringSteg.DEL3_AKTIVE_OPPGAVER.name());
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.START_POSISJON)).isNull();
+    }
+
+    @Test
+    void skal_fortsette_i_ny_task_nar_terskel_passeres() {
+        when(fssEksportRepository.hentBehandlinger(anyInt(), eq(100)))
+            .thenReturn(behandlinger(100));
+
+        var data = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        data.setProperty(FssGcpMigrasjonTask.STEG, FssGcpMigrasjonTask.MigreringSteg.DEL2_BEHANDLINGER.name());
+
+        task.doTask(data);
+
+        verify(fssEksportRepository, times(20)).hentBehandlinger(anyInt(), eq(100));
+        verify(gcpLosKlient, times(20)).lagreBulkData(any());
+
+        var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(prosessTaskTjeneste, times(1)).lagre(captor.capture());
+
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.STEG))
+            .isEqualTo(FssGcpMigrasjonTask.MigreringSteg.DEL2_BEHANDLINGER.name());
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.START_POSISJON)).isEqualTo("2000");
+    }
+
+    @Test
+    void skal_bruke_startposisjon_fra_prosesstaskdata() {
+        when(fssEksportRepository.hentBehandlinger(anyInt(), eq(100)))
+            .thenReturn(behandlinger(100))
+            .thenReturn(behandlinger(40)); // antall < bulk_størrelse trigger neste steg
+
+        var data = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        data.setProperty(FssGcpMigrasjonTask.STEG, FssGcpMigrasjonTask.MigreringSteg.DEL2_BEHANDLINGER.name());
+        data.setProperty(FssGcpMigrasjonTask.START_POSISJON, "6000");
+
+        task.doTask(data);
+
+        InOrder inOrder = inOrder(fssEksportRepository);
+        inOrder.verify(fssEksportRepository).hentBehandlinger(6000, 100);
+        inOrder.verify(fssEksportRepository).hentBehandlinger(6100, 100);
+
+        verify(gcpLosKlient, times(2)).lagreBulkData(any());
+
+        var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(prosessTaskTjeneste, times(1)).lagre(captor.capture());
+
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.STEG))
+            .isEqualTo(FssGcpMigrasjonTask.MigreringSteg.DEL3_AKTIVE_OPPGAVER.name());
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.START_POSISJON)).isNull();
+    }
+
+    @Test
+    void skal_kjore_del1_og_lage_task_for_del2() {
+        // regresjonstest av overgang del1/del2 etter innføring av flere taskinstanser per del
+        when(fssEksportRepository.hentOrganisasjonOgKøer())
+            .thenReturn(BulkDataWrapper.organisasjonOgKøOppset(null, List.of()));
+
+        var data = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        data.setProperty(FssGcpMigrasjonTask.STEG, FssGcpMigrasjonTask.MigreringSteg.DEL1_ORGANISASJON_OG_KØ.name());
+
+        task.doTask(data);
+
+        verify(fssEksportRepository).hentOrganisasjonOgKøer();
+        verify(gcpLosKlient, times(1)).lagreBulkData(any());
+
+        var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
+        verify(prosessTaskTjeneste, times(1)).lagre(captor.capture());
+
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.STEG))
+            .isEqualTo(FssGcpMigrasjonTask.MigreringSteg.DEL2_BEHANDLINGER.name());
+        assertThat(captor.getValue().getPropertyValue(FssGcpMigrasjonTask.START_POSISJON)).isNull();
+    }
+
+    @Test
+    void skal_ikke_lage_ny_task_nar_del6_gar_til_del7() {
+        // regresjonstest av overgang fra del6 etter innføring av flere taskinstanser per del
+        when(fssEksportRepository.hentStatistikkEnhetYtelseBehandling(anyInt(), eq(100)))
+            .thenReturn(statistikkEnhetYtelseBehandling(40));
+
+        var data = ProsessTaskData.forProsessTask(FssGcpMigrasjonTask.class);
+        data.setProperty(FssGcpMigrasjonTask.STEG, FssGcpMigrasjonTask.MigreringSteg.DEL6_STATISTIKK_EYB.name());
+
+        task.doTask(data);
+
+        verify(fssEksportRepository).hentStatistikkEnhetYtelseBehandling(0, 100);
+        verify(gcpLosKlient, times(1)).lagreBulkData(any());
+        verifyNoInteractions(prosessTaskTjeneste);
+    }
+
+    private static BulkDataWrapper behandlinger(int antall) {
+        List<BehandlingDataDto> list = Collections.nCopies(antall, null);
+        return BulkDataWrapper.behandlinger(list);
+    }
+
+    private static BulkDataWrapper statistikkEnhetYtelseBehandling(int antall) {
+        List<StatEnhetYtelseBehandlingDataDto> list = Collections.nCopies(antall, null);
+        return BulkDataWrapper.statistikkEnhetYtelseBehandling(list);
+    }
+}


### PR DESCRIPTION
Foreslår terskelverdi på 2000. Fortsetter i ny prosesstask når denne nås. 
Fikser cursor-lekkasjen ved å droppe getResultStream().
Utover dette er så lite som mulig rørt.

Har lagt på tester som demonstrerer overgangene mellom prosesstasker.